### PR TITLE
Protect polling function

### DIFF
--- a/polling.lua
+++ b/polling.lua
@@ -36,17 +36,25 @@ bot.init()
 
 api.firstUpdate()
 while true do -- Start a loop while the bot should be running.
-	local res = api.getUpdates(last_update+1) -- Get the latest updates
-	if res then
-		-- clocktime_last_update = os.clock()
-		for i=1, #res.result do -- Go through every new message.
-			last_update = res.result[i].update_id
-			--print(last_update)
-			current.h = current.h + 1
-			main.parseMessageFunction(res.result[i])
+	local status, err = pcall(
+	function ()
+		local res = api.getUpdates(last_update+1) -- Get the latest updates
+		if res then
+			-- clocktime_last_update = os.clock()
+			for i=1, #res.result do -- Go through every new message.
+				last_update = res.result[i].update_id
+				--print(last_update)
+				current.h = current.h + 1
+				processUpdate(res.result[i])
+			end
+		else
+			print('Connection error')
 		end
-	else
-		print('Connection error')
+	end)
+	if err then 
+		print(err)
+		api.sendLog(err)
+		if err:match('interrupted') then return end
 	end
 	if last_cron ~= os.date('%H') then -- Run cron jobs every hour.
 		last_cron = os.date('%H')


### PR DESCRIPTION
Make polling protected so it can't be interrupted by Bot API spikes.
I'm saying this because of such an error which doesn't terminate execution of the code:
```
lua: ./lua/methods.lua:40: Expected value but found invalid token at character 1
stack traceback:
        [C]: in function 'decode'
        ./lua/methods.lua:40: in function <./lua/methods.lua:38>
        (...tail calls...)
        ./polling.lua:173: in main chunk
        [C]: in ?
```
Well, forget about line numbers, it's all about `local res = api.getUpdates(last_update+1)`
Is this the main reason why bots freeze? I don't know, but I've seen my clone frozen because of this, there is no "Connection Error" message, it's about an inner exception, maybe an inner `Error()`.