### PR TITLE
Small typo and formatting fixes

### DIFF
--- a/locales/en.po
+++ b/locales/en.po
@@ -6,13 +6,2755 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: GroupButler 4.0\n"
-"Report-Msgid-Bugs-To: https://telegram.me/baconnn\n"
-"POT-Creation-Date: 2016-08-27 17:50+0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-07-02 17:25+0100\n"
 "PO-Revision-Date: 2016-08-27 17:50+0300\n"
 "Last-Translator: Nicholas Guriev <guriev-ns@ya.ru>\n"
 "Language-Team: English\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: lua/main.lua:112
+msgid "🐞 Sorry, a *bug* occurred"
+msgstr ""
+
+#: lua/main.lua:134
+#, lua-format
+msgid ""
+"\n"
+"Hello everyone!\n"
+"My name is %s, and I'm a bot made to help administrators in their hard "
+"work.\n"
+"Unfortunately I can't work in normal groups. If you need me, please ask the "
+"creator to convert this group to a supergroup and then add me again.\n"
+msgstr ""
+
+#: lua/methods.lua:159
+msgid "I don't have enough permissions to restrict users"
+msgstr ""
+
+#: lua/methods.lua:161
+msgid "I'm not an admin, I can't kick people"
+msgstr ""
+
+#: lua/methods.lua:163
+msgid "I can't kick or ban an admin"
+msgstr ""
+
+#: lua/methods.lua:165
+msgid "There is no need to unban in a normal group"
+msgstr ""
+
+#: lua/methods.lua:167
+msgid "This user is not a chat member"
+msgstr ""
+
+#: lua/plugins/antispam.lua:32 lua/plugins/onmessage.lua:157
+#: lua/plugins/warn.lua:101
+msgid "banned"
+msgstr ""
+
+#: lua/plugins/antispam.lua:33 lua/plugins/onmessage.lua:154
+#: lua/plugins/warn.lua:105
+msgid "kicked"
+msgstr ""
+
+#: lua/plugins/antispam.lua:34 lua/plugins/onmessage.lua:160
+#: lua/plugins/warn.lua:109
+msgid "muted"
+msgstr ""
+
+#: lua/plugins/antispam.lua:35 lua/plugins/dashboard.lua:143
+msgid "telegram.me links"
+msgstr ""
+
+#: lua/plugins/antispam.lua:36
+msgid "Channels messages"
+msgstr ""
+
+#: lua/plugins/antispam.lua:75
+#, lua-format
+msgid "%s %s for <b>spam</b>! (%d/%d)"
+msgstr ""
+
+#: lua/plugins/antispam.lua:80
+#, lua-format
+msgid "%s, spam is not allowed here. Next time you will be restricted"
+msgstr ""
+
+#: lua/plugins/antispam.lua:86
+#, lua-format
+msgid "%s, this kind of spam is not allowed in this chat (<b>%d/%d</b>)"
+msgstr ""
+
+#: lua/plugins/antispam.lua:90
+msgid "telegram.me link"
+msgstr ""
+
+#: lua/plugins/antispam.lua:90
+msgid "message from a channel"
+msgstr ""
+
+#: lua/plugins/antispam.lua:111
+msgid "forwards are allowed"
+msgstr ""
+
+#: lua/plugins/antispam.lua:113
+msgid "warn for forwarding"
+msgstr ""
+
+#: lua/plugins/antispam.lua:115
+msgid "forwards will be deleted"
+msgstr ""
+
+#: lua/plugins/antispam.lua:119
+msgid "links are allowed"
+msgstr ""
+
+#: lua/plugins/antispam.lua:121
+msgid "warn for links"
+msgstr ""
+
+#: lua/plugins/antispam.lua:123
+msgid "links will be deleted"
+msgstr ""
+
+#: lua/plugins/antispam.lua:139
+msgid "You can't go lower"
+msgstr ""
+
+#: lua/plugins/antispam.lua:141
+msgid "You can't go higher"
+msgstr ""
+
+#: lua/plugins/antispam.lua:149
+#, lua-format
+msgid "New value: %d"
+msgstr ""
+
+#: lua/plugins/antispam.lua:170
+msgid "Allow/forbid telegram.me links"
+msgstr ""
+
+#: lua/plugins/antispam.lua:172
+msgid "Allow/forbid forwarded messages from channels"
+msgstr ""
+
+#: lua/plugins/antispam.lua:174
+msgid ""
+"Set how many times the bot should warn the user before kicking or banning him"
+msgstr ""
+
+#: lua/plugins/antispam.lua:176 lua/plugins/defaultpermissions.lua:58
+#: lua/plugins/floodmanager.lua:18 lua/plugins/logchannel.lua:46
+#: lua/plugins/menu.lua:50 lua/plugins/private_settings.lua:17
+msgid "Description not available"
+msgstr ""
+
+#: lua/plugins/antispam.lua:202
+msgid "Kick 👞"
+msgstr ""
+
+#: lua/plugins/antispam.lua:204
+msgid "Ban 🔨"
+msgstr ""
+
+#: lua/plugins/antispam.lua:206
+msgid "Mute 👝"
+msgstr ""
+
+#: lua/plugins/antispam.lua:252 lua/plugins/floodmanager.lua:124
+#: lua/plugins/logchannel.lua:128 lua/plugins/mediasettings.lua:96
+#: lua/plugins/menu.lua:239
+msgid "You're no longer an admin"
+msgstr ""
+
+#: lua/plugins/antispam.lua:254
+msgid ""
+"*Anti-spam Settings*\n"
+"Choose which kind of spam you want to forbid\n"
+"• ✅ = *Allowed*\n"
+"• ❌ = *Not allowed*\n"
+"• 🗑 = *Delete*\n"
+"When set to `delete` 🗑, the bot doesn't warn users until they are about to "
+"be kicked/banned/muted (at the second-to-last warning).\n"
+msgstr ""
+
+#: lua/plugins/antispam.lua:316
+msgid "_The whitelist was already empty_"
+msgstr ""
+
+#: lua/plugins/antispam.lua:319
+#, lua-format
+msgid ""
+"*Whitelist cleaned*\n"
+"%d links have been removed"
+msgstr ""
+
+#: lua/plugins/antispam.lua:328 lua/plugins/antispam.lua:337
+#: lua/plugins/antispam.lua:369
+msgid "_I can't find a url in this message_"
+msgstr ""
+
+#: lua/plugins/antispam.lua:331
+#, lua-format
+msgid "%d link(s) will be whitelisted"
+msgstr ""
+
+#: lua/plugins/antispam.lua:333 lua/plugins/antispam.lua:365
+#, lua-format
+msgid ""
+"\n"
+"%d links were already in the list"
+msgstr ""
+
+#: lua/plugins/antispam.lua:345
+msgid ""
+"_The whitelist is empty_.\n"
+"Use `/wl [links]` to add some links to the whitelist"
+msgstr ""
+
+#: lua/plugins/antispam.lua:348
+msgid ""
+"Whitelisted links:\n"
+"\n"
+msgstr ""
+
+#: lua/plugins/antispam.lua:360
+msgid "_I can't find any url in this message_"
+msgstr ""
+
+#: lua/plugins/antispam.lua:363
+#, lua-format
+msgid "%d link(s) removed from the whitelist"
+msgstr ""
+
+#: lua/plugins/antispam.lua:380
+msgid "_Whitelist of channels is empty_"
+msgstr ""
+
+#: lua/plugins/antispam.lua:382
+#, lua-format
+msgid ""
+"*Whitelisted channels:*\n"
+"%s\"):format(table.concat(channels, '\n"
+msgstr ""
+
+#: lua/plugins/antispam.lua:391 lua/plugins/antispam.lua:410
+msgid "_I can't find a channel ID in your message_"
+msgstr ""
+
+#: lua/plugins/backup.lua:99
+#, lua-format
+msgid ""
+"<i>I'm sorry, this command has been used for the last time less then 3 hours "
+"ago by</i> %s (ask him for the file).\\nWait [<code>%s</code>] to use it "
+"again\n"
+"\t\t\t\t\t"
+msgstr ""
+
+#: lua/plugins/backup.lua:106
+msgid "*Sent in private*"
+msgstr ""
+
+#: lua/plugins/backup.lua:119
+#, lua-format
+msgid "Download of the file failed with code %s"
+msgstr ""
+
+#: lua/plugins/backup.lua:125
+#, lua-format
+msgid "Chat IDs don't match (%s and %s)"
+msgstr ""
+
+#: lua/plugins/backup.lua:151
+#, lua-format
+msgid ""
+"This is not a valid backup file.\n"
+"Reason: invalid name (%s)"
+msgstr ""
+
+#: lua/plugins/backup.lua:156
+msgid "Invalid input. Please reply to a document"
+msgstr ""
+
+#: lua/plugins/backup.lua:159
+msgid ""
+"Invalid input. Please reply to the backup file (/snap command to get it)"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:73
+msgid ""
+"Use -/+ to edit the value, then select a timeframe to temporarily ban the "
+"user"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:80 lua/plugins/banhammer.lua:93
+msgid ""
+"I can't kick this user.\n"
+"Either I'm not an admin, or the targeted user is!"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:86
+#, lua-format
+msgid "%s kicked %s!"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:99 lua/plugins/banhammer.lua:116
+#, lua-format
+msgid "%s banned %s!"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:104
+msgid "_Use this command in reply to a forwarded message_"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:110 lua/plugins/banhammer.lua:192
+msgid ""
+"I can't kick this user.\n"
+"I am not allowed to ban or the target user is an admin"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:122
+msgid "_An admin can't be unbanned_"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:127
+msgid "This user is not banned!"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:131
+#, lua-format
+msgid "%s unbanned by %s!"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:142
+msgid "You don't have the permissions to restrict members"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:146
+msgid ""
+"Tap on the -/+ buttons to change this value. Then select a timeframe to "
+"execute the ban"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:155
+msgid "You can't set a lower value"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:163
+msgid "Stop!!!"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:179
+msgid "hours"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:183
+msgid "days"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:187
+msgid "minutes"
+msgstr ""
+
+#: lua/plugins/banhammer.lua:196
+#, lua-format
+msgid "User banned for %d %s"
+msgstr ""
+
+#: lua/plugins/configure.lua:34
+msgid "🛠 Menu"
+msgstr ""
+
+#: lua/plugins/configure.lua:35
+msgid "⚡️ Antiflood"
+msgstr ""
+
+#: lua/plugins/configure.lua:36
+msgid "🌈 Media"
+msgstr ""
+
+#: lua/plugins/configure.lua:37
+msgid "🚫 Antispam"
+msgstr ""
+
+#: lua/plugins/configure.lua:38
+msgid "📥 Log channel"
+msgstr ""
+
+#: lua/plugins/configure.lua:48
+msgid "⛔️ Default permissions"
+msgstr ""
+
+#: lua/plugins/configure.lua:61
+#, lua-format
+msgid ""
+"<b>%s</b>\n"
+"<i>Change the settings of your group</i>"
+msgstr ""
+
+#: lua/plugins/configure.lua:65
+msgid "_I've sent you the keyboard via private message_"
+msgstr ""
+
+#: lua/plugins/configure.lua:77
+msgid "<i>Change the settings of your group</i>"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:13 lua/plugins/floodmanager.lua:26
+msgid "✅ | ON"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:15 lua/plugins/floodmanager.lua:28
+msgid "❌ | OFF"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:20 lua/plugins/menu.lua:153
+#: lua/plugins/menu.lua:209
+msgid "👞 kick"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:22
+msgid "🔨️ ️ban"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:24 lua/plugins/floodmanager.lua:38
+#: lua/plugins/menu.lua:157 lua/plugins/menu.lua:213
+msgid "👁 mute"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:28 lua/plugins/floodmanager.lua:56
+msgid "Texts"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:29 lua/plugins/floodmanager.lua:57
+msgid "Forwards"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:30 lua/plugins/dashboard.lua:147
+#: lua/plugins/floodmanager.lua:58 lua/plugins/mediasettings.lua:33
+msgid "Stickers"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:31 lua/plugins/dashboard.lua:139
+#: lua/plugins/floodmanager.lua:59 lua/plugins/mediasettings.lua:24
+msgid "Images"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:32 lua/plugins/dashboard.lua:140
+#: lua/plugins/floodmanager.lua:60 lua/plugins/mediasettings.lua:25
+msgid "GIFs"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:33 lua/plugins/dashboard.lua:141
+#: lua/plugins/floodmanager.lua:61 lua/plugins/mediasettings.lua:26
+msgid "Videos"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:47
+#, lua-format
+msgid "- *Status*: `%s`\n"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:48
+#, lua-format
+msgid ""
+"- *Action* to perform when an user floods: `%s`\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:50
+#, lua-format
+msgid ""
+"- Number of messages allowed *every 5 seconds*: `%d`\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:52
+#, lua-format
+msgid ""
+"- *Ignored media*:\n"
+"\t\t\t%s"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:60
+msgid "Settings"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:61
+msgid "Admins"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:64 lua/plugins/menu.lua:173 lua/utilities.lua:620
+msgid "Rules"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:65 lua/plugins/help.lua:303
+msgid "Extra commands"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:68
+msgid "Flood settings"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:69
+msgid "Media settings"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:80
+msgid "Navigate this message to see *all the info* about this group!"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:84
+msgid "_I've sent you the group dashboard via private message_"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:99
+msgid "🚫 This group does not exist"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:106
+msgid ""
+"🚷 You are not a member of the chat. You can't see the settings of a private "
+"group."
+msgstr ""
+
+#: lua/plugins/dashboard.lua:113
+msgid "ℹ️ Group ► Settings"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:117
+msgid "ℹ️ Group ► Rules"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:125
+msgid "I got kicked out of this group 😓"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:127
+msgid "ℹ️ Group ► Admin list"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:131
+msgid "ℹ️ Group ► Extra"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:135
+msgid "ℹ️ Group ► Flood"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:142 lua/plugins/mediasettings.lua:28
+msgid "Documents"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:144 lua/plugins/mediasettings.lua:30
+msgid "Vocal messages"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:145 lua/plugins/mediasettings.lua:31
+msgid "Links"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:146 lua/plugins/mediasettings.lua:32
+msgid "Music"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:148 lua/plugins/mediasettings.lua:34
+msgid "Contacts"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:149 lua/plugins/mediasettings.lua:35
+msgid "Games"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:150 lua/plugins/mediasettings.lua:36
+msgid "Locations"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:152
+msgid ""
+"*Current media settings*:\n"
+"\n"
+msgstr ""
+
+#: lua/plugins/dashboard.lua:163
+msgid "ℹ️ Group ► Media"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:46
+msgid ""
+"Permission to send messages. If disabled, the user won't be able to send any "
+"kind of message."
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:49
+msgid ""
+"Permission to send media (audio, documents, pictures, videos, video messages "
+"and voice messages). Implies the permission to send messages.\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:53
+msgid ""
+"Permission to send other types of messages (GIFs, games, stickers and use "
+"inline bots). Implies the permission to send media.\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:56
+msgid ""
+"When disabled, user's messages that contain a link won't show the web page "
+"preview."
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:63
+msgid "Send messages"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:64
+msgid "Send media"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:65
+msgid "Send other types of media"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:66
+msgid "Show web page preview"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:112
+msgid "You don't have the permission to restrict members!"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:114
+msgid ""
+"*Default Permissions*\n"
+"From this menu you can change the default permissions that will be granted "
+"when a new member joins.\n"
+"\n"
+"_Only the administrators with the permission to restrict a member can access "
+"this menu._\n"
+"\n"
+"Tap on the name of a permission for a description of what kind of messages "
+"it will influence.\n"
+msgstr ""
+
+#: lua/plugins/defaultpermissions.lua:138
+#, lua-format
+msgid ""
+"Setting saved, but I can't edit the buttons because you are too fast! Please "
+"wait %d seconds."
+msgstr ""
+
+#: lua/plugins/extra.lua:41
+#, lua-format
+msgid "This media has been saved as a response to %s"
+msgstr ""
+
+#: lua/plugins/extra.lua:55
+#, lua-format
+msgid "Command '%s' saved!"
+msgstr ""
+
+#: lua/plugins/extra.lua:78
+#, lua-format
+msgid "Commands deleted: `%s`"
+msgstr ""
+
+#: lua/plugins/extra.lua:80
+#, lua-format
+msgid ""
+"\n"
+"Commands not found: `%s`"
+msgstr ""
+
+#: lua/plugins/extra.lua:132
+#, lua-format
+msgid "_Please_ [start me](%s) _so I can send you the answer_"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:12
+msgid "⚖ Current sensitivity. Tap on the + or the - to change it"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:14
+msgid ""
+"Choose which media must be ignored by the antiflood (the bot won't consider "
+"them).\n"
+"✅: ignored\n"
+"❌: not ignored"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:34
+msgid "👞️ kick"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:36
+msgid "🔨 ️ban"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:91
+msgid "Flooders will be banned"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:94
+msgid "Flooders will be kicked"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:97
+msgid "Flooders will be muted"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:106 lua/plugins/floodmanager.lua:113
+#, lua-format
+msgid "%d is not a valid value!\n"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:127
+msgid ""
+"You can manage the antiflood settings from here.\n"
+"\n"
+"It is also possible to choose which type of messages the antiflood will "
+"ignore (✅)\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:135
+msgid "Antiflood settings"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:153
+#, lua-format
+msgid "❎ [%s] will be ignored by the anti-flood"
+msgstr ""
+
+#: lua/plugins/floodmanager.lua:156
+#, lua-format
+msgid "🚫 [%s] won't be ignored by the anti-flood"
+msgstr ""
+
+#: lua/plugins/help.lua:12
+#, lua-format
+msgid ""
+"\n"
+"Hello %s 👋🏼, nice to meet you!\n"
+"I'm Group Butler, the first administration bot using the official Bot API.\n"
+"\n"
+"*I can do a lot of cool stuff*, here's a short list:\n"
+"• I can *kick* or *ban* users\n"
+"• You can use me to set the group rules\n"
+"• I have a flexible *anti-flood* system\n"
+"• I can *welcome new users* with a customizable message, or if you want with "
+"a gif or a sticker\n"
+"• I can *warn* users, and ban them when they reach the maximum number of "
+"warnings\n"
+"• I can also warn, kick, or ban users when they post specific media\n"
+"…and more, below you can find the \"all commands\" button to get the whole "
+"list!\n"
+"\n"
+"I work better if you add me to the group administrators (otherwise I won't "
+"be able to kick or ban)!\n"
+msgstr ""
+
+#: lua/plugins/help.lua:28
+msgid ""
+"\n"
+"This bot works only in supergroups.\n"
+"\n"
+"To work properly, [it needs to be admin in your group](https://telegram.me/"
+"GroupButler_ch/104), so it can kick or ban people if needed.\n"
+"Only the group owner can promote it :)\n"
+"\n"
+"You can use `/, ! or #` to trigger a command.\n"
+"\n"
+"Group Butler saves the adminlist of a group in its databse to avoid to send "
+"too many requests to Telegram.\n"
+"This list is updated every 5 hours, so there could be some differences "
+"between who the bot thinks are the admins and who the admins actually are, "
+"if during the 5 hours timeframe some users have been prmoted/demoted.\n"
+"It's possible to force the bot to update its adminlist with `/cache`.\n"
+"\n"
+"Remember: you have to use commands  *in the group*, unless they are "
+"specifically designed for private chats (see \"private\" tab).\n"
+msgstr ""
+
+#: lua/plugins/help.lua:43
+msgid "In this menu you will find all the available commands"
+msgstr ""
+
+#: lua/plugins/help.lua:45
+msgid ""
+"\n"
+"*Commands that work in private*:\n"
+"\n"
+"• `/mysettings`: show a keyboard that allows you to change your personal "
+"settings, such as choosing if receive the rules in private when you join a "
+"group or if receive reports made with the `@admin` command\n"
+"• `/echo [text]` : the bot will send the text back, formatted with markdown\n"
+"• `/about` : show some useful informations about the bot\n"
+"• `/groups` : show the list of the discussion groups\n"
+"• `/id`: get your id\n"
+"• `/start` : show the initial message\n"
+"• `/help` : show this message\n"
+msgstr ""
+
+#: lua/plugins/help.lua:57
+msgid ""
+"\n"
+"*Commands available for every user in a group*:\n"
+"\n"
+"• `/dashboard`: see all the informations about the group\n"
+"• `/rules`: show the group rules\n"
+"• `/adminlist`: show the administrators of the group\n"
+"• `/help`: receive the help message\n"
+"• `!kickme`: the bot will kick you\n"
+"*Note*: `/dashboard`, `/adminlist`, `/modlist` and `/staff`replies always in "
+"private. If the bot is unable to reach an user, he will ask in the group to "
+"that user to be started, but just if _silent mode_ is off.\n"
+"With `/rules`, the bot always answer in the group for admins, but with "
+"normal users the message is sent in the group or in private according to the "
+"group settings.\n"
+"\n"
+"• `@admin` (by reply): report a message to the admins of the group (the bot "
+"will forward it in prvate). This ability could be turned off from the group "
+"settings. A description of the report can be added.\n"
+"Admins need to give their consense to receive reports from users, with `/"
+"mysettings` command\n"
+msgstr ""
+
+#: lua/plugins/help.lua:72
+msgid ""
+"\n"
+"*Admins: info about the group*\n"
+"\n"
+"• `/setrules [group rules]`: set the new regulation for the group (the old "
+"will be overwritten).\n"
+"• `/setrules -`: delete the current rules.\n"
+"\n"
+"*Note*: the markdown is supported. If the text sent breaks the markdown, the "
+"bot will notify that something is wrong.\n"
+"For a correct use of the markdown, check [this post](https://telegram.me/"
+"GroupButler_ch/46) in the channel\n"
+"\n"
+"• `/setlink [link|-]`: set the group link, so it can be re-called by other "
+"admins, or unset it.\n"
+"If you are going to use it in a public supergroup, you do not need to append "
+"the group link. Just send `/setlink`\n"
+"• `/link`: get the group link, if already set.\n"
+"• `/msglink`: get the link to a message. Works only in public supergroups\n"
+"\n"
+"*Note*: the bot can recognize valid group links. If a link is not valid, you "
+"won't receive a reply.\n"
+msgstr ""
+
+#: lua/plugins/help.lua:89
+msgid ""
+"\n"
+"*Banhammer powers*\n"
+"A set of commands that let admins kick and ban people from a group, and get "
+"some information about an user.\n"
+"Kicked people can join back, banned people can't. Banned users are added to "
+"the group's blacklist. It's possible to blacklist users even if they are not "
+"part of the group.\n"
+"Only the administrators who have the permission to restrict users can use "
+"these commands, but `/status` can be used by all the admins.\n"
+"\n"
+"• `/kick [by reply|username|id|text mention]`: kick a user from the group.\n"
+"• `/ban [by reply|username|id|text mention]`: ban a user from the group.\n"
+"• `/tempban [by reply|username|id|text mention]`: ban an user for a specific "
+"amount of time. Use the returned keyboard to ban the user.\n"
+"Pass a value on a new line to use it as starting value. When a ban expires, "
+"the user won't be added back. Check the Telegram's restricted users list for "
+"pending unbans.\n"
+"• `/fwdban [by reply]`: ban the original sender of a forwarded message.\n"
+"• `/unban [by reply|username|id|text mention]`: unban the user from the "
+"group.\n"
+"• `/user [by reply|username|id|text mention]`: shows how many times the user "
+"has been banned *in all the groups*, and the warns received.\n"
+"• `/status [username|id]`: show the current status of the user `(member|"
+"restricted|kicked/left the chat|banned|admin/creator|never seen)`.\n"
+"Will also show the permissions the user *doesn't* have.\n"
+"\n"
+"*Antiflood*\n"
+"The \"antiflood\" is a system that auto-removes people that send many "
+"consecutive messages in a group.\n"
+"If on, the antiflood system will kick/ban flooders.\n"
+"\n"
+"• `/config` command, then `antiflood` button: manage the flood settings in "
+"private, with an inline keyboard. You can change the sensitivity, the action "
+"(kick/ban) to perform, and even set some exceptions.\n"
+msgstr ""
+
+#: lua/plugins/help.lua:112
+msgid ""
+"\n"
+"*Reports settings*\n"
+"`@admin` is an useful command to let users report some messages to the group "
+"admins.\n"
+"A reported message will be forwarded to the available admins.\n"
+"\n"
+"• `/config` command, then `menu` button: here you can find a voice, \"Report"
+"\". If turned on, users will be able to use `@admin` command.\n"
+"Only admins who accepted to receive reports (with `/mysettings` command) "
+"will be notified\n"
+"• `/mysettings` (in private): from here, you can choose if receive reports "
+"or not\n"
+"\n"
+"*Note*: admins can't use the `@admin` command, and users can't report admins "
+"with it."
+msgstr ""
+
+#: lua/plugins/help.lua:123
+msgid ""
+"\n"
+"*Welcome/goodbye settings*\n"
+"\n"
+"• `/config`, then `menu` tab: receive in private the menu keyboard. You will "
+"find an option to enable/disable welcome/goodbye messages.\n"
+"*Note*: goodbye messages don't work in large groups. This is a Telegram "
+"limitation that can't be avoided.\n"
+"\n"
+"*Custom welcome message*:\n"
+"• `/welcome Welcome $name, enjoy the group!`\n"
+"Write after `/welcome` your welcome message. `/goodbye` works in the same "
+"way.\n"
+"\n"
+"You can use some placeholders to include the name/username/id of the new "
+"member of the group\n"
+"Placeholders:\n"
+"`$username`: _will be replaced with the username_\n"
+"`$name`: _will be replaced with the name_\n"
+"`$id`: _will be replaced with the id_\n"
+"`$title`: _will be replaced with the group title_\n"
+"`$surname`: _will be replaced by the user's last name_\n"
+"`$rules`: _will be replaced by a link to the rules of the group. Please "
+"read_ [here](https://telegram.me/GroupButler_beta/26) _how to use it, or you "
+"will get an error for sure_\n"
+"*Note*: `$name`, `$surname`, and `$title` may not work properly within "
+"markdown markup.\n"
+"\n"
+"*GIF/sticker as welcome message*\n"
+"You can use a particular gif/sticker as welcome message. To set it, reply to "
+"the gif/sticker you want to set as welcome message with `/welcome`. Same "
+"goes for `/goodbye`\n"
+msgstr ""
+
+#: lua/plugins/help.lua:147
+msgid ""
+"*Whitelist settings*\n"
+"\n"
+"As you may know, the bot can warn/kick/ban who sends a telegram.me link "
+"(antispam settings) or any other link (media settings).\n"
+"The whitelist is a list of links that will be ignored by the bot.\n"
+"If an user sends a whitelisted link, he won't be warned or kicked.\n"
+"\n"
+"`/whitelist [link(s)]` or `/wl [link(s)]`: add one or more links to the "
+"whitelist.\n"
+"`/unwhitelist [link(s)]` or `/unwl [link(s)]`: remove one or more links from "
+"the whitelist.\n"
+"`/whitelist` or `/wl`: get the whitelist.\n"
+"`/whitelistl -` or `/wl -`: empty the whitelist.\n"
+"\n"
+"When the group link is saved with `/setlink`, it gets automatically added to "
+"the whitelist.\n"
+"\n"
+"*Why links are saved without* _https://_ *and* _www_*?*\n"
+"The bot auto-removes _https://, http:// and www_ from every link to reduce "
+"the possibility of having the same link saved twice.\n"
+msgstr ""
+
+#: lua/plugins/help.lua:164
+msgid ""
+"\n"
+"*Extra commands*\n"
+"#extra commands are a smart way to save your own custom commands.\n"
+"\n"
+"• `/extra [#trigger] [reply]`: set a reply to be sent when someone writes "
+"the trigger.\n"
+"_Example_ : with \"`/extra #hello Good morning!`\", the bot will reply "
+"\"Good morning!\" each time someone writes #hello.\n"
+"You can reply to a media (_photo, file, vocal, video, gif, audio_) with `/"
+"extra #yourtrigger` to save the #extra and receive that media each time you "
+"use # command\n"
+"• `/extra list`: get the list of your custom commands.\n"
+"• `/extra del [#trigger]`: delete the trigger and its message.\n"
+"\n"
+"*Note:* the markdown is supported. If the text sent breaks the markdown, the "
+"bot will notify that something is wrong.\n"
+"For a correct use of the markdown, check [this post](https://telegram.me/"
+"GroupButler_ch/46) in the channel.\n"
+"Now supports placeholders. Check the \"welcome\" tab for the list of the "
+"available placeholders\n"
+msgstr ""
+
+#: lua/plugins/help.lua:179
+msgid ""
+"\n"
+"*Warns*\n"
+"Warn are made to keep the count of the admonitions received by an user. Once "
+"an user has been warned for the defined number of times, he is kicked/banned "
+"by the bot.\n"
+"There are two different type of warns:\n"
+"- _normal warns_, given by an admin with the `/warn` command\n"
+"- _automatic warns_ (read: media warns and spam warns), given by the bot "
+"when someone sends a media that is not allowed in the chat, or spams other "
+"channels or telegram.me links.\n"
+"\n"
+"• `/warn [by reply]`: warn a user\n"
+"• `/sw`: you can place a `/sw` (_\"silent warn\"_) everywhere you want in "
+"your message. The bot will silently count the warn, but won't answer in the "
+"group unless the user reached the max. number of warnings.\n"
+"• `/nowarns [by reply]`: reset the warns received by an user (both normal "
+"and automatic warns).\n"
+"• `/warnmax [number]`: set the max number of the warns before the kick/ban.\n"
+"• `/warnmax media [number]`: set the max number of the warns before kick/ban "
+"when an unallowed media is sent.\n"
+"\n"
+"How to see how many warns a user has received (or to reset them): `/user` "
+"command.\n"
+"How to change the max. number of warnings allowed: `/config` command, then "
+"`menu` button.\n"
+"How to change the max. number of warnings allowed for medias: `/config` "
+"command, then `media` button.\n"
+"How to change the max. number of warnings allowed for spam: `/config` "
+"command, then `antispam` button.\n"
+msgstr ""
+
+#: lua/plugins/help.lua:198
+msgid ""
+"\n"
+"*Pinning messages*\n"
+"The \"48 hours limit\" to edit your own messages doesn't apply to bots.\n"
+"This command was born from the necessity of editing the pinned message "
+"without sending it again, maybe just to change few things.\n"
+"So with `/pin` you can generate a message to pin, and edit it how many times "
+"you want.\n"
+"\n"
+"• `/pin [text]`: the bot will send you back the text you used as argument, "
+"with markdown. You can pin the message and use `/pin [text]` again to edit "
+"it\n"
+"• `/pin`: the bot will find the latest message generate by `/pin`, if it "
+"still exists\n"
+"• `/newpin [text]`: forces the bot to send another message that will be "
+"saved as new target for `/pin`\n"
+"\n"
+"*Note*: `/pin` supports markdown, but only `$rules` and `$title` "
+"placeholders\n"
+msgstr ""
+
+#. TRANSLATORS: leave your contact information to reports mistakes in translation
+#: lua/plugins/help.lua:212
+msgid ""
+"\n"
+"*Group language*\"\n"
+"• `/lang`: choose the group language (can be changed in private too).\n"
+"\n"
+"*Note*: translators are volunteers, so I can't ensure the correctness of all "
+"the translations. And I can't force them to translate the new strings after "
+"each update (not translated strings are in english).\n"
+"\n"
+"Anyway, translations are open to everyone. If you want to translate the bot, "
+"see an [information](https://github.com/RememberTheAir/"
+"GroupButler#translators) on GitHub.\n"
+"Ask in the English /group for the `.po` file of your language.\n"
+"\n"
+"*Special characters*\n"
+"\n"
+"• `/config` command, then `menu` button: you will receive in private the "
+"menu keyboard.\n"
+"Here you will find two particular options: _Arab and RTL_.\n"
+"\n"
+"*Arab*: when Arab it's not allowed (🚫), everyone who will write an arab "
+"character will be kicked from the group.\n"
+"*Rtl*: it stands for 'Righ To Left' character, and it's the responsible of "
+"the weird service messages that are written in the opposite sense.\n"
+"When Rtl is not allowed (🚫), everyone that writes this character (or that "
+"has it in his name) will be kicked.\n"
+msgstr ""
+
+#: lua/plugins/help.lua:231
+msgid ""
+"\n"
+"*General group settings*\n"
+"\n"
+"`/config` or  `/settings`: manage the group settings in private from an "
+"inline keyboard.\n"
+"The inline keyboard has six sub-menus:\n"
+"\n"
+"*Menu*: manage the most important group settings\n"
+"*Antiflood*: turn on or off the antiflood, set its sensitivity and choose "
+"some media to ignore, if you want\n"
+"*Media*: choose which media to forbid in your group, and set the number of "
+"times that an user will be warned before being kicked/banned\n"
+"*Antispam*: choose which kind of spam you want to forbid (example: telegram."
+"me links, forwarded messages from channels)\n"
+"*Log channel*: choose which updates should be logged\n"
+"*Moderators*: promote or demote moderators\n"
+"\n"
+"*Bonus commands*:\n"
+"`/reportflood [number of messages]/[timeframe]`: set how many times users "
+"can use the @admin command within a certain timeframe.\n"
+"`/leave`: the bot will leave the group without deleting its data. Use this "
+"command only if you are going to add the bot to the group again\n"
+"`/snap`: generate a backup file that can be restored with `/import` (send "
+"the file in the group and reply to it). `/snap` can be used once every three "
+"days\n"
+msgstr ""
+
+#: lua/plugins/help.lua:250
+msgid ""
+"*Moderators*\n"
+"\n"
+"Moderators are normal users that can use some of the commands that are "
+"usually available only to the group administrators.\n"
+"\n"
+"By default, moderators only have the banhammer (they can use _/ban, /kick, /"
+"unban, /tempban, /warn, /nowarn, /block, /unblock, /user_).\n"
+"But their powers can be expanded or restricted by the administrators: there "
+"is a button in the /config menu, called _\"Moderators\"_, where the "
+"permissions of the moderators can be configured.\n"
+"\n"
+"By default, every admin can promote a new moderator, or demote an user who "
+"is already a mod.\n"
+"If you are the group owner, in the _\"Moderators\"_ section of the "
+"configuration menu you will be able to find a switch called _\"Admins can "
+"manage mods\"_.\n"
+"When disabled, the group administrators *can't promote or demote new "
+"moderators*, and also they won't be allowed to access the _\"Moderators\"_ "
+"section of the configuration menu (so they *won't be able to change the "
+"moderators permissions*).\n"
+"\n"
+"*Commands*\n"
+"`/promote [by reply|by username|by text mention|by ID]`: promote an user to "
+"moderator. If used on a moderator, it will update his name in the moderators "
+"list.\n"
+"`/demote [by reply|by username|by text mention|by ID]`: demote an "
+"moderator.\n"
+"`/modlist`: show the list of the moderators\n"
+"`/modlist -`: demote all the moderators (will clean the modlist)"
+msgstr ""
+
+#: lua/plugins/help.lua:267
+msgid ""
+"*Log channel informations*\n"
+"\n"
+"A log channel is a i18n(private)_ channel where the bot will record all the "
+"important events that will happen in your group.\n"
+"If you want to use this feature, you need to pair your group with a channel "
+"with the commands described below.\n"
+"All the events, by default, are *not logged*. Admins can choose which events "
+"to log from the `/config` menu -> `log channel` button.\n"
+"\n"
+"To pair a channel with a group, the *channel creator* must [add the bot to "
+"the channel administrators](telegram.me/gb_tutorials/4) (otherwise it won't "
+"be able to post), and send in the channel this command:\n"
+"`/setlog`\n"
+"Then, an admin of the group must forward in the group the message (\"`/"
+"setlog`\") sent in the channel. *Done*!\n"
+"(you can find a video-tutorial [here](https://telegram.me/GB_tutorials/8))\n"
+"\n"
+"A channel can be used as log by different groups.\n"
+"To change your log channel, simply repeat this process with another "
+"channel.\n"
+"\n"
+"`/unsetlog`: remove your current log channel\n"
+"`/logchannel`: get some informations about your log channel, if paired"
+msgstr ""
+
+#: lua/plugins/help.lua:291
+msgid "Banhammer"
+msgstr ""
+
+#: lua/plugins/help.lua:292
+msgid "Group info"
+msgstr ""
+
+#: lua/plugins/help.lua:295
+msgid "Report system"
+msgstr ""
+
+#: lua/plugins/help.lua:296
+msgid "Pin"
+msgstr ""
+
+#: lua/plugins/help.lua:299
+msgid "Languages"
+msgstr ""
+
+#: lua/plugins/help.lua:300
+msgid "Group configuration"
+msgstr ""
+
+#: lua/plugins/help.lua:304 lua/plugins/logchannel.lua:68
+msgid "Warns"
+msgstr ""
+
+#: lua/plugins/help.lua:307
+msgid "Welcome settings"
+msgstr ""
+
+#: lua/plugins/help.lua:308
+msgid "Links whitelist"
+msgstr ""
+
+#: lua/plugins/help.lua:327
+msgid "📢 Bot channel"
+msgstr ""
+
+#: lua/plugins/help.lua:328
+msgid "🌍 Select your language"
+msgstr ""
+
+#: lua/plugins/help.lua:331
+msgid "📕 All the commands"
+msgstr ""
+
+#: lua/plugins/help.lua:340
+msgid "Basics"
+msgstr ""
+
+#: lua/plugins/help.lua:341
+msgid "Admin commands"
+msgstr ""
+
+#: lua/plugins/help.lua:342
+msgid "Normal users commands"
+msgstr ""
+
+#: lua/plugins/help.lua:343
+msgid "Commands in private"
+msgstr ""
+
+#: lua/plugins/help.lua:345
+msgid "Log channel"
+msgstr ""
+
+#: lua/plugins/help.lua:361
+msgid "Back"
+msgstr ""
+
+#: lua/plugins/help.lua:384
+#, lua-format
+msgid "[Start me](%s) _to get the list of commands_"
+msgstr ""
+
+#: lua/plugins/help.lua:397
+msgid "Main menu"
+msgstr ""
+
+#: lua/plugins/help.lua:400
+msgid "Basic usage"
+msgstr ""
+
+#: lua/plugins/help.lua:403
+msgid "Commands for users (group)"
+msgstr ""
+
+#: lua/plugins/help.lua:406
+msgid "Available commands in private"
+msgstr ""
+
+#: lua/plugins/help.lua:409
+msgid "Available commands in a realm"
+msgstr ""
+
+#: lua/plugins/help.lua:412
+msgid "Log channel informations"
+msgstr ""
+
+#: lua/plugins/help.lua:415
+msgid "Informations about the moderators"
+msgstr ""
+
+#: lua/plugins/help.lua:419
+msgid "Available commands for admins"
+msgstr ""
+
+#: lua/plugins/help.lua:423
+msgid "Deprecated message, send /help again"
+msgstr ""
+
+#: lua/plugins/help.lua:428
+msgid "❗️ Already there"
+msgstr ""
+
+#: lua/plugins/links.lua:25
+msgid ""
+"*No link* for this group. Ask the owner to save it with `/setlink [group "
+"link]`"
+msgstr ""
+
+#: lua/plugins/links.lua:36
+msgid "Link *unset*"
+msgstr ""
+
+#: lua/plugins/links.lua:42 lua/plugins/links.lua:61
+#, lua-format
+msgid ""
+"The link has been set.\n"
+"*Here's the link*: %s"
+msgstr ""
+
+#: lua/plugins/links.lua:46
+msgid ""
+"This is not a *public supergroup*, so you need to write the link near `/"
+"setlink`"
+msgstr ""
+
+#: lua/plugins/links.lua:49
+msgid "This link is *not valid!*"
+msgstr ""
+
+#: lua/plugins/links.lua:58
+#, lua-format
+msgid ""
+"The link has been updated.\n"
+"*Here's the new link*: %s"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:12
+msgid "Log every time a user join the group"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:14
+msgid "Bans will be logged. I can't log manual bans"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:16
+msgid "Kicks will be logged. I can't log manual kicks"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:18
+msgid "Manual warns will be logged"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:20
+msgid "Forbidden media will be logged in the channel"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:22
+msgid ""
+"Spam links/forwards from channels will be logged in the channel, only if "
+"forbidden"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:24
+msgid "Log when an user is flooding (new log message every 5 flood messages)"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:26
+msgid "Log when an admin changes the group icon"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:28
+msgid "Log when an admin deletes the group icon"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:30
+msgid "Log when an admin change the group title"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:32
+msgid "Log pinned messages"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:34
+msgid ""
+"Log when an user who has been blocked is banned from the group (when he "
+"joins)"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:36
+msgid "Log when a new user is promoted to moderator"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:38
+msgid "Log when an user looses the role of moderator"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:40
+msgid "Log when someone demotes all the moderators with '/modlist -'"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:42
+msgid "Log when an admin removes the warning received by an user"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:44
+msgid "Log when an user reports a message with the @admin command"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:63
+msgid "Ban"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:64
+msgid "Kick"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:65 lua/utilities.lua:979
+msgid "Unban"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:66
+msgid "Tempban"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:67
+msgid "Report"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:69
+msgid "Warns resets"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:70
+msgid "New members"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:71
+msgid "Media warns"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:72
+msgid "Spam warns"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:73
+msgid "Flood"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:74
+msgid "Promotions"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:75
+msgid "Demotions"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:76
+msgid "All mods demoted"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:77
+msgid "New group icon"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:78
+msgid "Group icon removed"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:79
+msgid "New group title"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:80
+msgid "Pinned messages"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:81
+msgid "Users blocked and banned"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:82
+msgid "Users blocked"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:83
+msgid "Users unblocked"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:110
+msgid "You are not admin of this group"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:115
+msgid "User unbanned!"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:139
+msgid ""
+"*Select the events the will be logged in the channel*\n"
+"✅ = will be logged\n"
+"☑️ = won't be logged\n"
+"\n"
+"Tap on a voice to get further informations"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:166
+msgid "_Too many requests. Retry later_"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:168
+msgid "_I need to be admin in the channel_"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:175
+msgid "_Already using this channel_"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:178
+msgid "*Log channel added!*"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:181
+#, lua-format
+msgid "<i>%s</i> changed its log channel"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:184
+#, lua-format
+msgid "Logs of <i>%s</i> will be posted here"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:188
+msgid "_Only the channel creator can pair the chat with a channel_"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:192
+msgid "_I'm sorry, only private channels are supported for now_"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:196
+msgid "You have to *forward* the message from the channel"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:202 lua/plugins/logchannel.lua:211
+msgid "_This groups is not using a log channel_"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:205
+msgid "*Log channel removed*"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:216
+msgid ""
+"_This group has a log channel saved, but I'm not a member there, so I can't "
+"post/retrieve its info_"
+msgstr ""
+
+#: lua/plugins/logchannel.lua:222
+#, lua-format
+msgid ""
+"<b>This group has a log channel</b>\n"
+"Channel: <code>%s</code>"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:27
+msgid "Video messages"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:54
+#, lua-format
+msgid "Warnings | %d | kick"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:56
+#, lua-format
+msgid "Warnings | %d | mute"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:58
+#, lua-format
+msgid "Warnings | %d | ban"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:80
+msgid "❌ warning"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:83
+msgid "🗑 delete"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:89
+msgid "✅ allowed"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:98
+msgid ""
+"\n"
+"Tap on a buttom on the right to *change the setting*\n"
+"You can use the last lines to change how many warnings the bot will give "
+"before kicking/banning/muting someone.\n"
+"The number is not related the the normal `/warn` command.\n"
+"\n"
+"Possible settings: ✅ allowed, ❌ warning, 🗑 delete\n"
+"When a media is set to delete, the bot will give a warning *only* when the "
+"user is at one media from being punished\n"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:115
+msgid "⚠️ Tap on the right column"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:124
+msgid "⚙ The new value is too low ( < 1)"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:131
+msgid "⚙ The new value is too high ( > 12)"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:143
+msgid "👞 New status is kick"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:146
+msgid "👁 New status is 'mute'"
+msgstr ""
+
+#: lua/plugins/mediasettings.lua:149
+msgid "🔨 New status is ban"
+msgstr ""
+
+#. TRANSLATORS: these strings should be shorter than 200 characters
+#: lua/plugins/menu.lua:13
+msgid ""
+"When enabled, users will be able to report messages with the @admin command"
+msgstr ""
+
+#: lua/plugins/menu.lua:15
+msgid "Enable or disable the goodbye message. Can't be sent in large groups"
+msgstr ""
+
+#: lua/plugins/menu.lua:17
+msgid "Enable or disable the welcome message"
+msgstr ""
+
+#: lua/plugins/menu.lua:19
+msgid ""
+"When enabled, every time a new welcome message is sent, the previously sent "
+"welcome message is removed"
+msgstr ""
+
+#: lua/plugins/menu.lua:22
+msgid ""
+"When enabled, the bot doesn't answer in the group to /dashboard, /config "
+"and /help commands (it will just answer in private)\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/menu.lua:25
+msgid ""
+"Enable and disable the anti-flood system (more info in the /help message)"
+msgstr ""
+
+#: lua/plugins/menu.lua:28
+msgid ""
+"If the welcome message is enabled, it will include an inline button that "
+"will send to the user the rules in private\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/menu.lua:31
+msgid ""
+"When someone uses /rules\n"
+"👥: the bot will answer in the group (always, with admins)\n"
+"👤: the bot will answer in private"
+msgstr ""
+
+#: lua/plugins/menu.lua:35
+msgid ""
+"When someone uses an #extra\n"
+"👥: the bot will answer in the group (always, with admins)\n"
+"👤: the bot will answer in private"
+msgstr ""
+
+#: lua/plugins/menu.lua:39
+msgid ""
+"Select what the bot should do when someone sends a message with arab "
+"characters"
+msgstr ""
+
+#: lua/plugins/menu.lua:41
+msgid "Bots will be banned when added by normal users"
+msgstr ""
+
+#: lua/plugins/menu.lua:44
+msgid ""
+"Select what the bot should do when someone sends a message with the RTL "
+"character, or has it in his name"
+msgstr ""
+
+#: lua/plugins/menu.lua:46
+msgid ""
+"Change how many times a user has to be warned before being kicked/banned"
+msgstr ""
+
+#: lua/plugins/menu.lua:48
+msgid ""
+"Change the action to perform when a user reaches the max. number of warnings"
+msgstr ""
+
+#: lua/plugins/menu.lua:59
+msgid "The new value is too high ( > 12)"
+msgstr ""
+
+#: lua/plugins/menu.lua:66
+msgid "The new value is too low ( < 1)"
+msgstr ""
+
+#: lua/plugins/menu.lua:75
+msgid "New action on max number of warns received: ban"
+msgstr ""
+
+#: lua/plugins/menu.lua:78
+msgid "New action on max number of warns received: mute"
+msgstr ""
+
+#: lua/plugins/menu.lua:81
+msgid "New action on max number of warns received: kick"
+msgstr ""
+
+#: lua/plugins/menu.lua:88
+msgid "Action -> kick"
+msgstr ""
+
+#: lua/plugins/menu.lua:89
+msgid "Action -> ban"
+msgstr ""
+
+#: lua/plugins/menu.lua:90
+msgid "Action -> mute"
+msgstr ""
+
+#: lua/plugins/menu.lua:91
+msgid "Allowed ✅"
+msgstr ""
+
+#: lua/plugins/menu.lua:155
+msgid "🔨 ban"
+msgstr ""
+
+#: lua/plugins/menu.lua:159
+msgid "✅"
+msgstr ""
+
+#: lua/plugins/menu.lua:168
+msgid "Welcome"
+msgstr ""
+
+#: lua/plugins/menu.lua:169
+msgid "Goodbye"
+msgstr ""
+
+#: lua/plugins/menu.lua:170 lua/utilities.lua:616
+msgid "Extra"
+msgstr ""
+
+#: lua/plugins/menu.lua:171 lua/utilities.lua:617
+msgid "Anti-flood"
+msgstr ""
+
+#: lua/plugins/menu.lua:172 lua/utilities.lua:619
+msgid "Silent mode"
+msgstr ""
+
+#: lua/plugins/menu.lua:174 lua/utilities.lua:621
+msgid "Arab"
+msgstr ""
+
+#: lua/plugins/menu.lua:175 lua/utilities.lua:622
+msgid "RTL"
+msgstr ""
+
+#: lua/plugins/menu.lua:176 lua/utilities.lua:618
+msgid "Ban bots"
+msgstr ""
+
+#: lua/plugins/menu.lua:177 lua/utilities.lua:623
+msgid "Reports"
+msgstr ""
+
+#: lua/plugins/menu.lua:178
+msgid "Delete last welcome message"
+msgstr ""
+
+#: lua/plugins/menu.lua:179
+msgid "Welcome + rules button"
+msgstr ""
+
+#: lua/plugins/menu.lua:211
+msgid "🔨️ ban"
+msgstr ""
+
+#: lua/plugins/menu.lua:217
+msgid "Warns: "
+msgstr ""
+
+#: lua/plugins/menu.lua:222
+msgid "Action:"
+msgstr ""
+
+#: lua/plugins/menu.lua:241
+msgid ""
+"Manage the settings of the group. Click on the left column to get a small "
+"hint"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:112
+#, lua-format
+msgid "%s <b>banned</b> for flood!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:114
+#, lua-format
+msgid "%s <b>kicked</b> for flood!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:116
+#, lua-format
+msgid "%s <b>muted</b> for flood!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:165
+#, lua-format
+msgid ""
+"%s <b>%s</b>: media sent not allowed!\n"
+"❗ <code>%d/%d</code>"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:176
+#, lua-format
+msgid ""
+"%s, this type of media is <b>not allowed</b> in this chat.\n"
+"(<code>%d/%d</code>)"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:181
+#, lua-format
+msgid ""
+"%s, this type of media is <b>not allowed</b> in this chat.\n"
+"<i>Next time you will be banned, kicked, or muted.</i>"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:204
+#, lua-format
+msgid "%s <b>kicked</b>: RTL characters in names/messages are not allowed!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:207
+#, lua-format
+msgid "%s <b>banned</b>: RTL characters in names/messages are not allowed!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:210
+#, lua-format
+msgid "%s <b>muted</b>: RTL characters in names/messages are not allowed!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:226
+#, lua-format
+msgid "%s has been <b>kicked</b>: Arabic/Persian message detected!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:229
+#, lua-format
+msgid "%s has been <b>banned</b>: Arabic/Persian message detected!"
+msgstr ""
+
+#: lua/plugins/onmessage.lua:232
+#, lua-format
+msgid "%s has been <b>muted</b>: Arabic/Persian message detected!"
+msgstr ""
+
+#: lua/plugins/pin.lua:17
+msgid "Last message generated by `/pin` ^"
+msgstr ""
+
+#: lua/plugins/pin.lua:38
+msgid "Message edited. Check it here"
+msgstr ""
+
+#: lua/plugins/pin.lua:51
+msgid ""
+"The old message generated with `/pin` does not exist anymore, so I can't "
+"edit it. This is the new message that can be now pinned\n"
+"\t\t\t\t\t\t"
+msgstr ""
+
+#: lua/plugins/pin.lua:54
+msgid ""
+"This message can now be pinned. Use `/pin [new text]` to edit it without "
+"having to send it again"
+msgstr ""
+
+#: lua/plugins/private.lua:13
+msgid "Channel"
+msgstr ""
+
+#: lua/plugins/private.lua:14
+msgid "GitHub"
+msgstr ""
+
+#: lua/plugins/private.lua:15
+msgid "Rate me!"
+msgstr ""
+
+#: lua/plugins/private.lua:18
+msgid "👥 Groups"
+msgstr ""
+
+#: lua/plugins/private.lua:28
+msgid "Pong!"
+msgstr ""
+
+#: lua/plugins/private.lua:42 lua/plugins/private.lua:64
+#, lua-format
+msgid ""
+"\n"
+"This bot is based on [otouto](https://github.com/topkecleon/otouto) (AKA "
+"@mokubot, channel: @otouto), a multipurpose Lua bot.\n"
+"Group Butler wouldn't exist without it.\n"
+"\n"
+"The owner of this bot is @baconn, do not pm him: use /groups command "
+"instead.\n"
+"\n"
+"Bot version: `%s`\n"
+"*Some useful links:*\n"
+msgstr ""
+
+#: lua/plugins/private.lua:56 lua/plugins/private.lua:79
+#, lua-format
+msgid "You can find the list of our support groups in [this channel](%s)"
+msgstr ""
+
+#: lua/plugins/private.lua:77
+msgid "🔙 back"
+msgstr ""
+
+#: lua/plugins/private_settings.lua:11
+msgid ""
+"When you join a group moderated by this bot, you will receive the group "
+"rules in private"
+msgstr ""
+
+#: lua/plugins/private_settings.lua:13
+msgid ""
+"\n"
+"\t\t\tIf enabled, you will receive all of the messages reported with the "
+"@admin command in the groups you are moderating\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/private_settings.lua:46
+msgid "Rules on join"
+msgstr ""
+
+#: lua/plugins/private_settings.lua:47
+msgid "Users reports"
+msgstr ""
+
+#: lua/plugins/private_settings.lua:65
+msgid "Change your private settings"
+msgstr ""
+
+#: lua/plugins/private_settings.lua:76
+msgid "⚙ Setting applied"
+msgstr ""
+
+#: lua/plugins/report.lua:19
+#, lua-format
+msgid "• <b>Message reported by</b>: %s (<code>%d</code>)"
+msgstr ""
+
+#: lua/plugins/report.lua:22
+#, lua-format
+msgid ""
+"\n"
+"\n"
+"• <b>Reported message sent by</b>: %s (<code>%d</code>)\n"
+"\t\t"
+msgstr ""
+
+#: lua/plugins/report.lua:28
+#, lua-format
+msgid ""
+"\n"
+"• <b>Group</b>: <a href=\"%s\">%s</a>"
+msgstr ""
+
+#: lua/plugins/report.lua:30
+#, lua-format
+msgid ""
+"\n"
+"• <b>Group</b>: %s"
+msgstr ""
+
+#: lua/plugins/report.lua:33
+#, lua-format
+msgid ""
+"\n"
+"\n"
+"• <a href=\"%s\">Go to the message</a>"
+msgstr ""
+
+#: lua/plugins/report.lua:38
+#, lua-format
+msgid ""
+"\n"
+"• <b>Description</b>: <i>%s</i>"
+msgstr ""
+
+#: lua/plugins/report.lua:47
+msgid "Address this report"
+msgstr ""
+
+#: lua/plugins/report.lua:92
+#, lua-format
+msgid "_Invalid value:_ number of times allowed (`input: %d`)"
+msgstr ""
+
+#: lua/plugins/report.lua:94
+#, lua-format
+msgid "_Invalid value:_ time (`input: %d`)"
+msgstr ""
+
+#: lua/plugins/report.lua:99
+#, lua-format
+msgid ""
+"*New parameters saved*.\n"
+"Users will be able to use @admin %d times/%d minutes"
+msgstr ""
+
+#: lua/plugins/report.lua:120
+#, lua-format
+msgid ""
+"_Please, do not abuse this command. It can be used %d times every %d "
+"minutes_.\n"
+"Wait other %d minutes, %d seconds."
+msgstr ""
+
+#: lua/plugins/report.lua:131
+#, lua-format
+msgid "_Reported to %d admin(s)_"
+msgstr ""
+
+#: lua/plugins/report.lua:142
+msgid ""
+"You closed this issue and deleted all the other reports sent to the admins"
+msgstr ""
+
+#: lua/plugins/report.lua:151
+msgid "This message is too old (>2 days)"
+msgstr ""
+
+#: lua/plugins/report.lua:162
+msgid "❕ Already (being) adressed"
+msgstr ""
+
+#: lua/plugins/report.lua:164
+msgid "Close issue"
+msgstr ""
+
+#: lua/plugins/report.lua:174
+#, lua-format
+msgid "%s has/will address this report"
+msgstr ""
+
+#: lua/plugins/report.lua:182
+msgid ""
+"This button will delete all the reports sent to the other admins. Tap it "
+"again to confirm"
+msgstr ""
+
+#: lua/plugins/report.lua:190
+msgid "(issue closed by you)"
+msgstr ""
+
+#: lua/plugins/rules.lua:26
+msgid "🚫 Unknown or non-existent group"
+msgstr ""
+
+#: lua/plugins/rules.lua:34
+msgid ""
+"🚷 You are not a member of this chat. You can't read the rules of a private "
+"group."
+msgstr ""
+
+#: lua/plugins/rules.lua:64
+msgid "Please write something after `/setrules`"
+msgstr ""
+
+#: lua/plugins/rules.lua:69
+msgid "Rules have been deleted."
+msgstr ""
+
+#: lua/plugins/rules.lua:82
+msgid "New rules *saved successfully*!"
+msgstr ""
+
+#: lua/plugins/service.lua:22
+#, lua-format
+msgid "_You (user ID: %d) are in the blocked list_"
+msgstr ""
+
+#: lua/plugins/service.lua:27
+msgid "_Admin mode is on: only the bot admin can add me to a new group_"
+msgstr ""
+
+#: lua/plugins/service.lua:41
+#, lua-format
+msgid ""
+"Hello everyone!\n"
+"\"My name is %s, and I'm a bot made to help administrators in their hard "
+"work.\n"
+"\t\t\t\t"
+msgstr ""
+
+#: lua/plugins/service.lua:46
+msgid ""
+"Yay! This group has been upgraded. You are great! Now I can work "
+"properly :)\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/service.lua:70
+#, lua-format
+msgid "I've been removed from %s [<code>%d</code>], one of your subgroups"
+msgstr ""
+
+#: lua/plugins/setlang.lua:24 lua/plugins/setlang.lua:34
+msgid "*List of available languages*:"
+msgstr ""
+
+#: lua/plugins/setlang.lua:30
+msgid "You are not an admin"
+msgstr ""
+
+#. TRANSLATORS: replace 'English' with the name of your language
+#: lua/plugins/setlang.lua:43
+msgid "English language is *set*"
+msgstr ""
+
+#: lua/plugins/setlang.lua:44
+msgid ""
+".\n"
+"Please note that translators are volunteers, and some strings of the "
+"translation you selected _could not have been translated yet_\n"
+msgstr ""
+
+#: lua/plugins/users.lua:11
+msgid "can't change the chat title/description/icon"
+msgstr ""
+
+#: lua/plugins/users.lua:12
+msgid "can't send messages"
+msgstr ""
+
+#: lua/plugins/users.lua:13
+msgid "can't delete messages"
+msgstr ""
+
+#: lua/plugins/users.lua:14
+msgid "can't invite users/generate a link"
+msgstr ""
+
+#: lua/plugins/users.lua:15
+msgid "can't restrict members"
+msgstr ""
+
+#: lua/plugins/users.lua:16
+msgid "can't pin messages"
+msgstr ""
+
+#: lua/plugins/users.lua:17
+msgid "can't promote new admins"
+msgstr ""
+
+#: lua/plugins/users.lua:18
+msgid "can't send photos/videos/documents/audios/voice messages/video messages"
+msgstr ""
+
+#: lua/plugins/users.lua:19
+msgid "can't send stickers/GIFs/games/use inline bots"
+msgstr ""
+
+#: lua/plugins/users.lua:20
+msgid "can't show link previews"
+msgstr ""
+
+#: lua/plugins/users.lua:24
+msgid "🔄️ Refresh cache"
+msgstr ""
+
+#: lua/plugins/users.lua:76
+msgid "Remove warnings"
+msgstr ""
+
+#: lua/plugins/users.lua:84
+#, lua-format
+msgid ""
+"*User ID*: `%d`\n"
+"`Warnings`: *%d*\n"
+"`Media warnings`: *%d*\n"
+"`Spam warnings`: *%d*\n"
+msgstr ""
+
+#: lua/plugins/users.lua:122
+msgid "That user has nothing to do with this chat"
+msgstr ""
+
+#: lua/plugins/users.lua:128
+#, lua-format
+msgid "%s is banned from this group"
+msgstr ""
+
+#: lua/plugins/users.lua:129
+#, lua-format
+msgid "%s left the group or has been kicked and unbanned"
+msgstr ""
+
+#: lua/plugins/users.lua:130
+#, lua-format
+msgid "%s is an admin"
+msgstr ""
+
+#: lua/plugins/users.lua:131
+#, lua-format
+msgid "%s is the group creator"
+msgstr ""
+
+#: lua/plugins/users.lua:132
+#, lua-format
+msgid "%s has nothing to do with this chat"
+msgstr ""
+
+#: lua/plugins/users.lua:133
+#, lua-format
+msgid "%s is a chat member"
+msgstr ""
+
+#: lua/plugins/users.lua:134
+#, lua-format
+msgid "%s is a restricted"
+msgstr ""
+
+#: lua/plugins/users.lua:145
+#, lua-format
+msgid ""
+"\n"
+"Restrictions: <i>%s</i>"
+msgstr ""
+
+#: lua/plugins/users.lua:158
+msgid "Reply to a user or mention them by username or numerical ID"
+msgstr ""
+
+#: lua/plugins/users.lua:166
+msgid ""
+"I've never seen this user before.\n"
+"This command works by reply, username, user ID or text mention.\n"
+"If you're using it by username and want to teach me who the user is, forward "
+"me one of his messages"
+msgstr ""
+
+#: lua/plugins/users.lua:184 lua/plugins/users.lua:241
+#, lua-format
+msgid ""
+"📌 Status: `CACHED`\n"
+"⌛ ️Remaining: `%s`\n"
+"👥 Admins cached: `%d`"
+msgstr ""
+
+#: lua/plugins/users.lua:195
+#, lua-format
+msgid "Message N° %d"
+msgstr ""
+
+#: lua/plugins/users.lua:212 lua/plugins/warn.lua:153
+msgid "You are not allowed to use this button"
+msgstr ""
+
+#: lua/plugins/users.lua:223
+#, lua-format
+msgid ""
+"The number of warnings received by this user has been <b>reset</b>, by %s"
+msgstr ""
+
+#: lua/plugins/users.lua:234
+#, lua-format
+msgid ""
+"The adminlist has just been updated. You must wait 10 minutes from the last "
+"refresh (wait  %d seconds)"
+msgstr ""
+
+#: lua/plugins/users.lua:245
+#, lua-format
+msgid "✅ Updated. Next update in %s"
+msgstr ""
+
+#: lua/plugins/warn.lua:12
+msgid "Remove warn"
+msgstr ""
+
+#: lua/plugins/warn.lua:40
+msgid "Max number of warnings changed (media).\n"
+msgstr ""
+
+#: lua/plugins/warn.lua:45
+msgid "Max number of warnings changed.\n"
+msgstr ""
+
+#: lua/plugins/warn.lua:49
+#, lua-format
+msgid ""
+"*Old* value was %d\n"
+"*New* max is %d"
+msgstr ""
+
+#: lua/plugins/warn.lua:58
+msgid "Yes"
+msgstr ""
+
+#: lua/plugins/warn.lua:58
+msgid "No"
+msgstr ""
+
+#: lua/plugins/warn.lua:62
+msgid ""
+"Do you want to continue and reset *all* the warnings received by *all* the "
+"users of the group?"
+msgstr ""
+
+#: lua/plugins/warn.lua:79
+#, lua-format
+msgid ""
+"\n"
+"\t\t\tDone! %s has been forgiven.\n"
+"\t\t\t<b>Warnings found</b>: <i>normal warnings %s, media warnings %s, spam "
+"warnings %s</i>\n"
+"\t\t\t"
+msgstr ""
+
+#: lua/plugins/warn.lua:99
+#, lua-format
+msgid "%s <b>%s</b>: reached the max number of warnings (<code>%d/%d</code>)"
+msgstr ""
+
+#: lua/plugins/warn.lua:116
+msgid ""
+"I can't kick this user.\n"
+"Either I am not an admin, or the user is!"
+msgstr ""
+
+#: lua/plugins/warn.lua:136
+#, lua-format
+msgid "%s <b>has been warned</b> (<code>%d/%d</code>)"
+msgstr ""
+
+#: lua/plugins/warn.lua:161
+msgid "The number of warnings received by this user is already <i>zero</i>"
+msgstr ""
+
+#: lua/plugins/warn.lua:165
+#, lua-format
+msgid "<b>Warn removed!</b> (%d/%d)"
+msgstr ""
+
+#: lua/plugins/warn.lua:168
+#, lua-format
+msgid ""
+"\n"
+"(Admin: %s)"
+msgstr ""
+
+#: lua/plugins/warn.lua:177
+#, lua-format
+msgid "Done. All the warnings of this group have been erased by %s"
+msgstr ""
+
+#: lua/plugins/warn.lua:179
+msgid "_Action aborted_"
+msgstr ""
+
+#: lua/plugins/welcome.lua:92 lua/plugins/welcome.lua:187
+msgid "Read the rules"
+msgstr ""
+
+#: lua/plugins/welcome.lua:110
+#, lua-format
+msgid "Hi %s!"
+msgstr ""
+
+#: lua/plugins/welcome.lua:122
+msgid "Welcome and...?"
+msgstr ""
+
+#: lua/plugins/welcome.lua:145
+#, lua-format
+msgid "A form of media has been set as the welcome message: `%s`"
+msgstr ""
+
+#: lua/plugins/welcome.lua:147
+msgid "Reply to a `sticker` or a `gif` to set them as the *welcome message*"
+msgstr ""
+
+#: lua/plugins/welcome.lua:165
+msgid "*Custom welcome message saved!*"
+msgstr ""
+
+#: lua/utilities.lua:371
+msgid "More info [here](https://telegram.me/GB_tutorials/12)"
+msgstr ""
+
+#: lua/utilities.lua:374 lua/utilities.lua:376 lua/utilities.lua:378
+#, lua-format
+msgid ""
+"Inline link formatted incorrectly. Check the text between brackets -> \\[]"
+"()\n"
+"%s"
+msgstr ""
+
+#: lua/utilities.lua:379
+msgid ""
+"This text breaks the markdown.\n"
+"More info about a proper use of markdown [here](https://telegram.me/"
+"GB_tutorials/10) and [here](https://telegram.me/GB_tutorials/12)."
+msgstr ""
+
+#: lua/utilities.lua:382
+msgid ""
+"This message is too long. Max lenght allowed by Telegram: 4000 characters"
+msgstr ""
+
+#: lua/utilities.lua:384
+msgid ""
+"One of the URLs that should be placed in an inline button seems to be "
+"invalid (not an URL). Please check it"
+msgstr ""
+
+#: lua/utilities.lua:385
+msgid "One of the inline buttons you are trying to set is missing the URL"
+msgstr ""
+
+#: lua/utilities.lua:386
+msgid "One of the inline buttons you are trying to set doesn't have a name"
+msgstr ""
+
+#: lua/utilities.lua:387
+msgid "Please input a text"
+msgstr ""
+
+#: lua/utilities.lua:390
+msgid "Text not valid: unknown formatting error"
+msgstr ""
+
+#: lua/utilities.lua:552
+msgid "-*empty*-"
+msgstr ""
+
+#: lua/utilities.lua:591
+#, lua-format
+msgid ""
+"<b>👤 Creator</b>\n"
+"└ %s\n"
+"\n"
+"<b>👥 Admins</b> (%d)\n"
+"%s"
+msgstr ""
+
+#: lua/utilities.lua:598
+msgid "No commands set"
+msgstr ""
+
+#: lua/utilities.lua:601
+msgid "List of custom commands:\n"
+msgstr ""
+
+#: lua/utilities.lua:609
+msgid ""
+"Current settings for *the group*:\n"
+"\n"
+msgstr ""
+
+#: lua/utilities.lua:610
+#, lua-format
+msgid "*Language*: %s\n"
+msgstr ""
+
+#: lua/utilities.lua:614
+msgid "Welcome message"
+msgstr ""
+
+#: lua/utilities.lua:615
+msgid "Goodbye message"
+msgstr ""
+
+#: lua/utilities.lua:624
+msgid "Welcome button"
+msgstr ""
+
+#: lua/utilities.lua:660
+msgid "*Welcome type*: `GIF / sticker`\n"
+msgstr ""
+
+#: lua/utilities.lua:662
+msgid "*Welcome type*: `custom message`\n"
+msgstr ""
+
+#: lua/utilities.lua:664
+msgid "*Welcome type*: `default message`\n"
+msgstr ""
+
+#: lua/utilities.lua:671
+#, lua-format
+msgid "Warns (`standard`): *%s*\n"
+msgstr ""
+
+#: lua/utilities.lua:672
+#, lua-format
+msgid ""
+"Warns (`media`): *%s*\n"
+"\n"
+msgstr ""
+
+#: lua/utilities.lua:673
+msgid "✅ = _enabled / allowed_\n"
+msgstr ""
+
+#: lua/utilities.lua:674
+msgid "🚫 = _disabled / not allowed_\n"
+msgstr ""
+
+#: lua/utilities.lua:675
+msgid "👥 = _sent in group (always for admins)_\n"
+msgstr ""
+
+#: lua/utilities.lua:676
+msgid "👤 = _sent in private_"
+msgstr ""
+
+#: lua/utilities.lua:682
+msgid "@admin command disabled"
+msgstr ""
+
+#: lua/utilities.lua:683
+msgid "Welcome message won't be displayed from now"
+msgstr ""
+
+#: lua/utilities.lua:684
+msgid "Goodbye message won't be displayed from now"
+msgstr ""
+
+#: lua/utilities.lua:685
+msgid "#extra commands are now available only for moderator"
+msgstr ""
+
+#: lua/utilities.lua:686
+msgid "Anti-flood is now off"
+msgstr ""
+
+#: lua/utilities.lua:687
+msgid "/rules will reply in private (for users)"
+msgstr ""
+
+#: lua/utilities.lua:688
+msgid "Silent mode is now off"
+msgstr ""
+
+#: lua/utilities.lua:689
+msgid "Links preview disabled"
+msgstr ""
+
+#: lua/utilities.lua:690
+msgid "Welcome message without a button for the rules"
+msgstr ""
+
+#: lua/utilities.lua:693
+msgid "@admin command enabled"
+msgstr ""
+
+#: lua/utilities.lua:694
+msgid "Welcome message will be displayed"
+msgstr ""
+
+#: lua/utilities.lua:695
+msgid "Goodbye message will be displayed"
+msgstr ""
+
+#: lua/utilities.lua:696
+msgid "#extra commands are now available for all"
+msgstr ""
+
+#: lua/utilities.lua:697
+msgid "Anti-flood is now on"
+msgstr ""
+
+#: lua/utilities.lua:698
+msgid "/rules will reply in the group (with everyone)"
+msgstr ""
+
+#: lua/utilities.lua:699
+msgid "Silent mode is now on"
+msgstr ""
+
+#: lua/utilities.lua:700
+msgid "Links preview enabled"
+msgstr ""
+
+#: lua/utilities.lua:701
+msgid "The welcome message will have a button for the rules"
+msgstr ""
+
+#: lua/utilities.lua:714
+msgid ""
+"This setting is enabled, but the goodbye message won't be displayed in large "
+"groups, because I can't see service messages about left members"
+msgstr ""
+
+#: lua/utilities.lua:723
+msgid "Start me"
+msgstr ""
+
+#: lua/utilities.lua:724
+msgid "_Please message me first so I can message you_"
+msgstr ""
+
+#: lua/utilities.lua:822
+msgid "Reply to an user or mention him"
+msgstr ""
+
+#: lua/utilities.lua:833 lua/utilities.lua:843
+msgid ""
+"Unknown user.\n"
+"Please forward a message from them to me"
+msgstr ""
+
+#: lua/utilities.lua:858
+#, lua-format
+msgid "<b>Chat</b>: %s [#chat%d]"
+msgstr ""
+
+#: lua/utilities.lua:883 lua/utilities.lua:885 lua/utilities.lua:892
+#: lua/utilities.lua:894 lua/utilities.lua:896
+#, lua-format
+msgid ""
+"%s\n"
+"• %s\n"
+"• <b>By</b>: %s"
+msgstr ""
+
+#: lua/utilities.lua:888
+msgid "Get the new photo"
+msgstr ""
+
+#: lua/utilities.lua:899
+#, lua-format
+msgid ""
+"%s\n"
+"• %s\n"
+"• <b>By</b>: %s\n"
+"• <i>Reported to %d admin(s)</i>"
+msgstr ""
+
+#: lua/utilities.lua:902
+#, lua-format
+msgid ""
+"#BLOCKBAN\n"
+"• %s\n"
+"• <b>User</b>: %s [#id%d]"
+msgstr ""
+
+#: lua/utilities.lua:906
+#, lua-format
+msgid ""
+"%s\n"
+"• %s\n"
+"• <b>User</b>: %s"
+msgstr ""
+
+#: lua/utilities.lua:908
+#, lua-format
+msgid ""
+"\n"
+"• <b>Added by</b>: %s [#id%d]"
+msgstr ""
+
+#: lua/utilities.lua:921
+#, lua-format
+msgid ""
+"#%s\n"
+"• <b>Admin</b>: %s [#id%d]\n"
+"• %s\n"
+"• <b>User</b>: %s [#id%d]\n"
+"• <b>Count</b>: <code>%d/%d</code>"
+msgstr ""
+
+#: lua/utilities.lua:924
+#, lua-format
+msgid ""
+"\n"
+"<b>Action</b>: <i>%s</i>"
+msgstr ""
+
+#: lua/utilities.lua:932
+#, lua-format
+msgid ""
+"#%s\n"
+"• <b>Admin</b>: %s [#id%s]\n"
+"• %s\n"
+"• <b>User</b>: %s [#id%s]\n"
+"• <b>Warns found</b>: <i>normal: %s, for media: %s, spamwarns: %s</i>"
+msgstr ""
+
+#: lua/utilities.lua:942
+#, lua-format
+msgid ""
+"#%s\n"
+"• <b>Admin</b>: %s [#id%s]\n"
+"• %s\n"
+"• <b>Moderator</b>: %s [#id%s]"
+msgstr ""
+
+#: lua/utilities.lua:946
+#, lua-format
+msgid ""
+"#%s\n"
+"• <b>Admin</b>: %s [#id%s]\n"
+"• %s\n"
+msgstr ""
+
+#: lua/utilities.lua:949
+#, lua-format
+msgid "• <i>Users involved: %d</i>"
+msgstr ""
+
+#: lua/utilities.lua:951
+#, lua-format
+msgid "• <b>User</b>: %s [#id%d]"
+msgstr ""
+
+#: lua/utilities.lua:962
+#, lua-format
+msgid ""
+"#%s\n"
+"• <b>Admin</b>: %s [#id%s]\n"
+"• %s\n"
+"• <b>User</b>: %s [#id%s]\n"
+"• <b>Duration</b>: %d days, %d hours"
+msgstr ""
+
+#: lua/utilities.lua:971
+#, lua-format
+msgid ""
+"#%s\n"
+"• <b>Admin</b>: %s [#id%s]\n"
+"• %s\n"
+"• <b>User</b>: %s [#id%s]"
+msgstr ""
+
+#: lua/utilities.lua:990
+msgid "Go to the message"
+msgstr ""
+
+#: lua/utilities.lua:1034
+#, lua-format
+msgid "This command has been removed \\[[read more](%s)]"
+msgstr ""

--- a/lua/plugins/admin.lua
+++ b/lua/plugins/admin.lua
@@ -48,7 +48,7 @@ plugin.cron = nil
 local function bot_leave(chat_id)
 	local res = api.leaveChat(chat_id)
 	if not res then
-		return 'Check the id, it could be wrong'
+		return 'Check the id, it could be wrong.'
 	else
 		db:srem('bot:groupsid', chat_id)
 		db:sadd('bot:groupsid:removed', chat_id)

--- a/lua/plugins/antispam.lua
+++ b/lua/plugins/antispam.lua
@@ -77,7 +77,7 @@ function plugin.onEveryMessage(msg)
 				else
 					if status == 'del' and warns_received == max_allowed - 1 then
 						api.deleteMessage(msg.chat.id, msg.message_id)
-						api.sendReply(msg, i18n('%s, spam is not allowed here. The next time you will be restricted'):format(name),
+						api.sendReply(msg, i18n('%s, spam is not allowed here. Next time you will be restricted'):format(name),
 							'html')
 					elseif status == 'del' then
 						--just delete
@@ -110,7 +110,7 @@ local function toggleAntispamSetting(chat_id, key)
 		if new == 'alwd' then
 			return i18n("forwards are allowed")
 		elseif new == 'warn' then
-			return i18n("warn for forwards")
+			return i18n("warn for forwarding")
 		elseif new == 'del' then
 			return i18n("forwards will be deleted")
 		end
@@ -171,7 +171,7 @@ local function get_alert_text(key)
 	elseif key == 'forwards' then
 		return i18n("Allow/forbid forwarded messages from channels")
 	elseif key == 'warns' then
-		return i18n("Set how many times the bot should warn the user before kick/ban him")
+		return i18n("Set how many times the bot should warn the user before kicking or banning him")
 	else
 		return i18n("Description not available")
 	end
@@ -251,12 +251,12 @@ function plugin.onCallbackQuery(msg, blocks)
 		if not u.is_allowed('config', chat_id, msg.from) then
 			api.answerCallbackQuery(msg.cb_id, i18n("You're no longer an admin"))
 		else
-			local antispam_first = i18n([[*Anti-spam settings*
+			local antispam_first = i18n([[*Anti-spam Settings*
 Choose which kind of spam you want to forbid
 • ✅ = *Allowed*
 • ❌ = *Not allowed*
 • 🗑 = *Delete*
-When set on `delete`, the bot doesn't warn users until they are about to be kicked/banned/muted (at the second-to-last warning)
+When set to `delete` 🗑, the bot doesn't warn users until they are about to be kicked/banned/muted (at the second-to-last warning).
 ]])
 
 			local keyboard, text
@@ -316,7 +316,8 @@ function plugin.onTextMessage(msg, blocks)
 					text = i18n("_The whitelist was already empty_")
 				else
 					db:del(set)
-					text = i18n("*Whitelist cleaned*\n%d links have been removed"):format(n)
+					text = i18n([[*Whitelist cleaned*
+%d links have been removed]]):format(n)
 				end
 				api.sendReply(msg, text, true)
 			else
@@ -324,7 +325,7 @@ function plugin.onTextMessage(msg, blocks)
 				if msg.entities then
 					local links = urls_table(msg.entities, msg.text)
 					if not next(links) then
-						text = i18n("_I can't find any url in this message_")
+						text = i18n("_I can't find a url in this message_")
 					else
 						local new = db:sadd(('chat:%d:whitelist'):format(msg.chat.id), unpack(links))
 						text = i18n("%d link(s) will be whitelisted"):format(#links - (#links - new))
@@ -333,7 +334,7 @@ function plugin.onTextMessage(msg, blocks)
 						end
 					end
 				else
-					text = i18n("_I can't find any url in this message_")
+					text = i18n("_I can't find a url in this message_")
 				end
 				api.sendReply(msg, text, true)
 			end
@@ -341,7 +342,8 @@ function plugin.onTextMessage(msg, blocks)
 		if (blocks[1] == 'wl' or blocks[1] == 'whitelist') and not blocks[2] then
 			local links = db:smembers(('chat:%d:whitelist'):format(msg.chat.id))
 			if not next(links) then
-				api.sendReply(msg, i18n("_The whitelist is empty_.\nUse `/wl [links]` to add some links to the whitelist"), true)
+				api.sendReply(msg, i18n([[_The whitelist is empty_.
+Use `/wl [links]` to add some links to the whitelist]]), true)
 			else
 				local text = i18n("Whitelisted links:\n\n")
 				for i=1, #links do
@@ -364,7 +366,7 @@ function plugin.onTextMessage(msg, blocks)
 					end
 				end
 			else
-				text = i18n("_I can't find any url in this message_")
+				text = i18n("_I can't find a url in this message_")
 			end
 			api.sendReply(msg, text, true)
 		end
@@ -375,9 +377,11 @@ function plugin.onTextMessage(msg, blocks)
 		if blocks[1] == 'wlchan' and not blocks[2] then
 			local channels = db:smembers(('chat:%d:chanwhitelist'):format(msg.chat.id))
 			if not next(channels) then
-				api.sendReply(msg, i18n("_Whitelist of channels empty_"), true)
+				api.sendReply(msg, i18n("_Whitelist of channels is empty_"), true)
 			else
-				api.sendReply(msg, i18n("*Whitelisted channels:*\n%s"):format(table.concat(channels, '\n')), true)
+				api.sendReply(msg, i18n([[*Whitelisted channels:*
+%s"):format(table.concat(channels, '
+]]), true)
 			end
 		end
 		if blocks[1] == 'wlchan' and blocks[2] then
@@ -388,10 +392,12 @@ function plugin.onTextMessage(msg, blocks)
 			else
 				local text = ''
 				if next(channels.valid) then
-					text = text..("*Channels whitelisted*: `%s`\n"):format(table.concat(channels.valid, ', '))
+					text = text..([[*Channels whitelisted*: `%s`
+					]]):format(table.concat(channels.valid, ', '))
 				end
 				if next(channels.not_valid) then
-					text = text..("*Channels already whitelisted*: `%s`\n"):format(table.concat(channels.not_valid, ', '))
+					text = text..([[*Channels already whitelisted*: `%s`
+					]]):format(table.concat(channels.not_valid, ', '))
 				end
 
 				api.sendReply(msg, text, true)

--- a/lua/plugins/antispam.lua
+++ b/lua/plugins/antispam.lua
@@ -203,7 +203,7 @@ local function doKeyboard_antispam(chat_id)
 	elseif action == 'ban' then
 		action = i18n("Ban 🔨")
 	elseif action == 'mute' then
-		action = i18n("Mute 👁")
+		action = i18n("Mute 👝")
 	end
 
 	local line = {

--- a/lua/plugins/backup.lua
+++ b/lua/plugins/backup.lua
@@ -122,7 +122,7 @@ function plugin.onTextMessage(msg, blocks)
 							for chat_id, group_data in pairs(data) do
 								chat_id = tonumber(chat_id)
 								if tonumber(chat_id) ~= msg.chat.id then
-									text = i18n('Chat IDs don\'t match (%s and %s)'):format(tostring(chat_id), tostring(msg.chat.id))
+									text = i18n("Chat IDs don't match (%s and %s)"):format(tostring(chat_id), tostring(msg.chat.id))
 								else
 									--restoring sets
 									if group_data.sets and next(group_data.sets) then
@@ -148,7 +148,8 @@ function plugin.onTextMessage(msg, blocks)
 							end
 						end
 					else
-						text = i18n('This is not a valid backup file.\nReason: invalid name (%s)')
+						text = i18n([[This is not a valid backup file.
+Reason: invalid name (%s)]])
 							:format(tostring(msg.reply_to_message.document.file_name))
 					end
 				else

--- a/lua/plugins/banhammer.lua
+++ b/lua/plugins/banhammer.lua
@@ -70,15 +70,15 @@ function plugin.onTextMessage(msg, blocks)
 				end
 
 				local markup = markup_tempban(msg.chat.id, user_id)
-				api.sendReply(msg, i18n('Use -/+ to edit the value, then select a timeframe to temporary ban the user'), nil,
+				api.sendReply(msg, i18n('Use -/+ to edit the value, then select a timeframe to temporarily ban the user'), nil,
 					markup)
 			end
 			if blocks[1] == 'kick' then
 				local res, _, motivation = api.kickUser(chat_id, user_id)
 				if not res then
 					if not motivation then
-						motivation = i18n("I can't kick this user.\n"
-								.. "Either I'm not an admin, or the targeted user is!")
+						motivation = i18n([[I can't kick this user.
+Either I'm not an admin, or the targeted user is!]])
 					end
 					api.sendReply(msg, motivation, true)
 				else
@@ -90,8 +90,8 @@ function plugin.onTextMessage(msg, blocks)
 				local res, _, motivation = api.banUser(chat_id, user_id)
 				if not res then
 					if not motivation then
-						motivation = i18n("I can't kick this user.\n"
-								.. "Either I'm not an admin, or the targeted user is!")
+						motivation = i18n([[I can't kick this user.
+Either I'm not an admin, or the targeted user is!]])
 					end
 					api.sendReply(msg, motivation, true)
 				else
@@ -107,8 +107,8 @@ function plugin.onTextMessage(msg, blocks)
 					local res, _, motivation = api.banUser(chat_id, user_id)
 					if not res then
 						if not motivation then
-							motivation = i18n("I can't kick this user.\n"
-									.. "I am not allowed to ban or the target user is an admin")
+							motivation = i18n([[I can't kick this user.
+I am not allowed to ban or the target user is an admin]])
 						end
 						api.sendReply(msg, motivation, true)
 					else
@@ -189,8 +189,8 @@ function plugin.onCallbackQuery(msg, matches)
 			end
 			local res, _, motivation = api.banUser(msg.chat.id, user_id, until_date)
 			if not res then
-				motivation = motivation or i18n("I can't kick this user.\n"
-					.. "I am not allowed to ban or the target user is an admin")
+				motivation = motivation or i18n([[I can't kick this user.
+I am not allowed to ban or the target user is an admin]])
 				api.editMessageText(msg.chat.id, msg.message_id, motivation)
 			else
 				local text = i18n("User banned for %d %s"):format(time_value, timeframe_string)

--- a/lua/plugins/configure.lua
+++ b/lua/plugins/configure.lua
@@ -58,7 +58,8 @@ function plugin.onTextMessage(msg)
 			local keyboard = do_keyboard_config(chat_id, msg.from.id)
 			if not db:get('chat:'..chat_id..':title') then cache_chat_title(chat_id, msg.chat.title) end
 			local res = api.sendMessage(msg.from.id,
-				i18n("<b>%s</b>\n<i>Change the settings of your group</i>"):format(msg.chat.title:escape_html()), 'html', keyboard)
+				i18n([[<b>%s</b>
+<i>Change the settings of your group</i>]]):format(msg.chat.title:escape_html()), 'html', keyboard)
 			if not u.is_silentmode_on(msg.chat.id) then --send the responde in the group only if the silent mode is off
 				if res then
 					api.sendMessage(msg.chat.id, i18n("_I've sent you the keyboard via private message_"), true)
@@ -76,7 +77,7 @@ function plugin.onCallbackQuery(msg)
 	local text = i18n("<i>Change the settings of your group</i>")
 	local chat_title = get_chat_title(chat_id)
 	if chat_title then
-		text = ("<b>%s</b>\n"):format(chat_title:escape_html())..text
+		text = ('<b>%s</b>\n'):format(chat_title:escape_html())..text
 	end
 	api.editMessageText(msg.chat.id, msg.message_id, text, 'html', keyboard)
 end

--- a/lua/plugins/dashboard.lua
+++ b/lua/plugins/dashboard.lua
@@ -45,9 +45,12 @@ local function getFloodSettings_text(chat_id)
 		list_exc = list_exc..'• `'..translation..'`: '..exc_status..'\n'
 	end
 	return i18n("- *Status*: `%s`\n"):format(status)
-			.. i18n("- *Action* to perform when an user floods: `%s`\n"):format(action)
-			.. i18n("- Number of messages allowed *every 5 seconds*: `%d`\n"):format(num)
-			.. i18n("- *Ignored media*:\n%s"):format(list_exc)
+			.. i18n([[- *Action* to perform when an user floods: `%s`
+			]]):format(action)
+			.. i18n([[- Number of messages allowed *every 5 seconds*: `%d`
+			]]):format(num)
+			.. i18n([[- *Ignored media*:
+			%s]]):format(list_exc)
 end
 
 local function doKeyboard_dashboard(chat_id)

--- a/lua/plugins/defaultpermissions.lua
+++ b/lua/plugins/defaultpermissions.lua
@@ -43,17 +43,17 @@ end
 
 local function get_alert_text(key)
 	if key == 'can_send_messages' then
-		return i18n("Permission to send messages. If disabled, the user won't be able to send any kind of message")
+		return i18n("Permission to send messages. If disabled, the user won't be able to send any kind of message.")
 	elseif key == 'can_send_media_messages' then
 		return i18n(
-			[[Permission to send media (audios, documents, photos, videos, video notes and voice notes). Implies the permission to send messages
+			[[Permission to send media (audio, documents, pictures, videos, video messages and voice messages). Implies the permission to send messages.
 			]])
 	elseif key == 'can_send_other_messages' then
 		return i18n(
-			[[Permission to send other types of messages (GIFs, games, stickers and use inline bots). Implies the permission to send medias
+			[[Permission to send other types of messages (GIFs, games, stickers and use inline bots). Implies the permission to send media.
 			]])
 	elseif key == 'can_add_web_page_previews' then
-		return i18n("When disabled, user's messages with a link won't show the web page preview")
+		return i18n("When disabled, user's messages that contain a link won't show the web page preview.")
 	else
 		return i18n("Description not available")
 	end
@@ -109,11 +109,13 @@ function plugin.onCallbackQuery(msg, blocks)
 	else
 		local chat_id = msg.target_id
 		if not u.can(chat_id, msg.from.id, 'can_restrict_members') then
-			api.answerCallbackQuery(msg.cb_id, i18n("You don't have the permission to restrict members"))
+			api.answerCallbackQuery(msg.cb_id, i18n("You don't have the permission to restrict members!"))
 		else
-			local msg_text = i18n([[*Default permissions*
+			local msg_text = i18n([[*Default Permissions*
 From this menu you can change the default permissions that will be granted when a new member joins.
+
 _Only the administrators with the permission to restrict a member can access this menu._
+
 Tap on the name of a permission for a description of what kind of messages it will influence.
 ]])
 
@@ -133,7 +135,7 @@ Tap on the name of a permission for a description of what kind of messages it wi
 			end
 
 			if not res and code == 429 and retry_after then
-					popup_text = i18n("Setting saved, but I can't edit the buttons because you are too fast! Wait other %d seconds")
+					popup_text = i18n("Setting saved, but I can't edit the buttons because you are too fast! Please wait %d seconds.")
 						:format(retry_after)
 					show_alert = true
 			end

--- a/lua/plugins/defaultpermissions.lua
+++ b/lua/plugins/defaultpermissions.lua
@@ -111,8 +111,8 @@ function plugin.onCallbackQuery(msg, blocks)
 		if not u.can(chat_id, msg.from.id, 'can_restrict_members') then
 			api.answerCallbackQuery(msg.cb_id, i18n("You don't have the permission to restrict members"))
 		else
-			local msg_text = i18n([[*Deafult permissions*
-From this menu you can change the default permissions that will be granted when a new member join.
+			local msg_text = i18n([[*Default permissions*
+From this menu you can change the default permissions that will be granted when a new member joins.
 _Only the administrators with the permission to restrict a member can access this menu._
 Tap on the name of a permission for a description of what kind of messages it will influence.
 ]])

--- a/lua/plugins/floodmanager.lua
+++ b/lua/plugins/floodmanager.lua
@@ -124,7 +124,9 @@ function plugin.onCallbackQuery(msg, blocks)
 		api.answerCallbackQuery(msg.cb_id, i18n("You're no longer an admin"))
 	else
 		local header = i18n(
-			[[You can manage the antiflood settings from here.\n\nIt is also possible to choose which type of messages the antiflood will ignore (✅)
+			[[You can manage the antiflood settings from here.
+
+It is also possible to choose which type of messages the antiflood will ignore (✅)
 			]])
 
 		local text

--- a/lua/plugins/help.lua
+++ b/lua/plugins/help.lua
@@ -13,13 +13,13 @@ local function get_helped_string(key)
 Hello %s 👋🏼, nice to meet you!
 I'm Group Butler, the first administration bot using the official Bot API.
 
-*I can do a lot of cool stuffs*, here's a short list:
-• I can *kick or ban* users
+*I can do a lot of cool stuff*, here's a short list:
+• I can *kick* or *ban* users
 • You can use me to set the group rules
 • I have a flexible *anti-flood* system
 • I can *welcome new users* with a customizable message, or if you want with a gif or a sticker
 • I can *warn* users, and ban them when they reach the maximum number of warnings
-• I can also warn, kick or ban users when they post a specific media
+• I can also warn, kick, or ban users when they post specific media
 …and more, below you can find the "all commands" button to get the whole list!
 
 I work better if you add me to the group administrators (otherwise I won't be able to kick or ban)!

--- a/lua/plugins/links.lua
+++ b/lua/plugins/links.lua
@@ -39,7 +39,8 @@ function plugin.onTextMessage(msg, blocks)
 			if msg.chat.username then
 				link = 'https://telegram.me/'..msg.chat.username
 				local substitution = '['..msg.chat.title:escape_hard('link')..']('..link..')'
-				text = i18n("The link has been set.\n*Here's the link*: %s"):format(substitution)
+				text = i18n([[The link has been set.
+*Here's the link*: %s]]):format(substitution)
 			else
 				if not blocks[2] then
 					text = i18n("This is not a *public supergroup*, so you need to write the link near `/setlink`")
@@ -54,9 +55,11 @@ function plugin.onTextMessage(msg, blocks)
 						local title = msg.chat.title:escape_hard('link')
 						local substitution = '['..title..']('..link..')'
 						if not succ then
-							text = i18n("The link has been updated.\n*Here's the new link*: %s"):format(substitution)
+							text = i18n([[The link has been updated.
+*Here's the new link*: %s]]):format(substitution)
 						else
-							text = i18n("The link has been set.\n*Here's the link*: %s"):format(substitution)
+							text = i18n([[The link has been set.
+*Here's the link*: %s]]):format(substitution)
 						end
 					end
 				end

--- a/lua/plugins/logchannel.lua
+++ b/lua/plugins/logchannel.lua
@@ -9,7 +9,7 @@ local plugin = {}
 
 local function get_alert_text(key)
 	if key == 'new_chat_member' then
-		return i18n("Log every time an user join the group")
+		return i18n("Log every time a user join the group")
 	elseif key == 'ban' then
 		return i18n("Bans will be logged. I can't log manual bans")
 	elseif key == 'kick' then
@@ -31,7 +31,7 @@ local function get_alert_text(key)
 	elseif key == 'pinned_message' then
 		return i18n("Log pinned messages")
 	elseif key == 'blockban' then
-		return i18n("Log when an user who has been blocked is banned from the group (when he join)")
+		return i18n("Log when an user who has been blocked is banned from the group (when he joins)")
 	elseif key == 'promote' then
 		return i18n("Log when a new user is promoted to moderator")
 	elseif key == 'demote' then
@@ -189,7 +189,7 @@ function plugin.onTextMessage(msg, blocks)
 							end
 						end
 					else
-						api.sendReply(msg, i18n('_I\'m sorry, only private channels are supported for now_'), true)
+						api.sendReply(msg, i18n("_I'm sorry, only private channels are supported for now_"), true)
 					end
 				end
 			else
@@ -219,8 +219,8 @@ function plugin.onTextMessage(msg, blocks)
 					if channel_info and channel_info.result then
 						channel_identifier = channel_info.result.title
 					end
-					api.sendReply(msg, i18n(
-						'<b>This group has a log channel</b>\nChannel: <code>%s</code>'
+					api.sendReply(msg, i18n([[<b>This group has a log channel</b>
+Channel: <code>%s</code>]]
 						):format(channel_identifier:escape_html()), 'html')
 				end
 			end

--- a/lua/plugins/mediasettings.lua
+++ b/lua/plugins/mediasettings.lua
@@ -96,12 +96,12 @@ function plugin.onCallbackQuery(msg, blocks)
 		api.answerCallbackQuery(msg.cb_id, i18n("You're no longer an admin"))
 	else
 		local media_first = i18n([[
-Tap on a voice in the right to *change the setting*
-You can use the last lines to change how many warnings should the bot give before kicking/banning/muting someone.
+Tap on a buttom on the right to *change the setting*
+You can use the last lines to change how many warnings the bot will give before kicking/banning/muting someone.
 The number is not related the the normal `/warn` command.
 
-Medias possible statuses: ✅ allowed, ❌ warning, 🗑 delete.
-When a media is set on delete, the bot will give a warning *only* when the user is at one media from being punished
+Possible settings: ✅ allowed, ❌ warning, 🗑 delete
+When a media is set to delete, the bot will give a warning *only* when the user is at one media from being punished
 ]])
 
 		if blocks[1] == 'config' then
@@ -143,7 +143,7 @@ When a media is set on delete, the bot will give a warning *only* when the user 
 					cb_text = i18n("👞 New status is kick")
 				elseif current == 'kick' then
 					db:hset(hash, 'mediatype', 'mute')
-					cb_text = i18n("👁 New status is mute")
+					cb_text = i18n("👁 New status is 'mute'")
 				elseif current == 'mute' then
 					db:hset(hash, 'mediatype', 'ban')
 					cb_text = i18n("🔨 New status is ban")

--- a/lua/plugins/menu.lua
+++ b/lua/plugins/menu.lua
@@ -43,9 +43,9 @@ local function get_button_description(key)
 		return i18n(
 			"Select what the bot should do when someone sends a message with the RTL character, or has it in his name")
 	elseif key == 'warnsnum' then
-		return i18n("Change how many times an user has to be warned before being kicked/banned")
+		return i18n("Change how many times a user has to be warned before being kicked/banned")
 	elseif key == 'warnsact' then
-		return i18n("Change the action to perform when an user reaches the max. number of warnings")
+		return i18n("Change the action to perform when a user reaches the max. number of warnings")
 	else
 		return i18n("Description not available")
 	end

--- a/lua/plugins/onmessage.lua
+++ b/lua/plugins/onmessage.lua
@@ -31,7 +31,7 @@ end
 local function is_flooding_funct(msg)
 	if msg.media_group_id then
 		-- albums should count as one message
-		
+
 		local media_group_id_key = 'mediagroupidkey:'..msg.chat.id
 		if msg.media_group_id == db:get(media_group_id_key) then -- msg.media_group_id is a str
 			-- photo/video is from an already processed sent album
@@ -162,7 +162,8 @@ function plugin.onEveryMessage(msg)
 						if res then --kick worked
 							db:hdel('chat:'..msg.chat.id..':mediawarn', msg.from.id) --remove media warns
 							local message =
-								i18n('%s <b>%s</b>: media sent not allowed!\n❗️ <code>%d/%d</code>'):format(name, punishment, n, max)
+								i18n([[%s <b>%s</b>: media sent not allowed!
+❗ <code>%d/%d</code>]]):format(name, punishment, n, max)
 							api.sendMessage(msg.chat.id, message, 'html')
 						end
 
@@ -172,12 +173,13 @@ function plugin.onEveryMessage(msg)
 					else --max num not reached -> warn or delete
 						if media_status ~= 'del' then
 							local message =
-							i18n('%s, this type of media is <b>not allowed</b> in this chat.\n(<code>%d/%d</code>)'):format(name, n, max)
+							i18n([[%s, this type of media is <b>not allowed</b> in this chat.
+(<code>%d/%d</code>)]]):format(name, n, max)
 							api.sendReply(msg, message, 'html')
 						elseif media_status == 'del' and n + 1 >= max then
 							api.deleteMessage(msg.chat.id, msg.message_id)
 							local message = i18n([[%s, this type of media is <b>not allowed</b> in this chat.
-							<i>Next time you will be banned, kicked, or muted.</i>]]):format(name)
+<i>Next time you will be banned, kicked, or muted.</i>]]):format(name)
 							api.sendMessage(msg.chat.id, message, 'html')
 						elseif media_status == 'del' then
 							api.deleteMessage(msg.chat.id, msg.message_id)
@@ -199,13 +201,13 @@ function plugin.onEveryMessage(msg)
 				local res, message
 				if rtl_status == 'kick' then
 					res = api.kickUser(msg.chat.id, msg.from.id)
-					message = i18n("%s <b>kicked</b>: RTL character in names/messages are not allowed!")
+					message = i18n("%s <b>kicked</b>: RTL characters in names/messages are not allowed!")
 				elseif rtl_status == 'ban' then
 					res = api.banUser(msg.chat.id, msg.from.id)
-					message = i18n("%s <b>banned</b>: RTL character in names/messages are not allowed!")
+					message = i18n("%s <b>banned</b>: RTL characters in names/messages are not allowed!")
 				elseif rtl_status == 'mute' then
 					res = api.muteUser(msg.chat.id, msg.from.id)
-					message = i18n("%s <b>muted</b>: RTL character in names/messages are not allowed!")
+					message = i18n("%s <b>muted</b>: RTL characters in names/messages are not allowed!")
 				end
 				if res then
 					local name = u.getname_final(msg.from)
@@ -221,13 +223,13 @@ function plugin.onEveryMessage(msg)
 				local res, message
 				if arab_status == 'kick' then
 					res = api.kickUser(msg.chat.id, msg.from.id)
-					message = i18n("%s <b>kicked</b>: arab/persian message detected!")
+					message = i18n("%s has been <b>kicked</b>: Arabic/Persian message detected!")
 				elseif arab_status == 'ban' then
 					res = api.banUser(msg.chat.id, msg.from.id)
-					message = i18n("%s <b>banned</b>: arab/persian message detected!")
+					message = i18n("%s has been <b>banned</b>: Arabic/Persian message detected!")
 				elseif arab_status == 'mute' then
 					res = api.muteUser(msg.chat.id, msg.from.id)
-					message = i18n("%s <b>muted</b>: arab/persian message detected!")
+					message = i18n("%s has been <b>muted</b>: Arabic/Persian message detected!")
 				end
 				if res then
 					local name = u.getname_final(msg.from)

--- a/lua/plugins/onmessage.lua
+++ b/lua/plugins/onmessage.lua
@@ -176,9 +176,8 @@ function plugin.onEveryMessage(msg)
 							api.sendReply(msg, message, 'html')
 						elseif media_status == 'del' and n + 1 >= max then
 							api.deleteMessage(msg.chat.id, msg.message_id)
-							local message = i18n('
-									%s, this type of media is <b>not allowed</b> in this chat.\n<i>Next time you will be banned, kicked, or muted.</i>
-								'):format(name)
+							local message = i18n([[%s, this type of media is <b>not allowed</b> in this chat.
+							<i>Next time you will be banned, kicked, or muted.</i>]]):format(name)
 							api.sendMessage(msg.chat.id, message, 'html')
 						elseif media_status == 'del' then
 							api.deleteMessage(msg.chat.id, msg.message_id)

--- a/lua/plugins/onmessage.lua
+++ b/lua/plugins/onmessage.lua
@@ -176,9 +176,9 @@ function plugin.onEveryMessage(msg)
 							api.sendReply(msg, message, 'html')
 						elseif media_status == 'del' and n + 1 >= max then
 							api.deleteMessage(msg.chat.id, msg.message_id)
-							local message =
-							i18n([[%s, this type of media is <b>not allowed</b> in this chat.\n<i>The next time you will be banned/kicked/muted</i>
-								]]):format(name)
+							local message = i18n('
+									%s, this type of media is <b>not allowed</b> in this chat.\n<i>Next time you will be banned, kicked, or muted.</i>
+								'):format(name)
 							api.sendMessage(msg.chat.id, message, 'html')
 						elseif media_status == 'del' then
 							api.deleteMessage(msg.chat.id, msg.message_id)

--- a/lua/plugins/private.lua
+++ b/lua/plugins/private.lua
@@ -40,7 +40,13 @@ function plugin.onTextMessage(msg, blocks)
 	if blocks[1] == 'about' then
 		local keyboard = do_keyboard_credits()
 		local text = i18n([[
-This bot is based on [otouto](https://github.com/topkecleon/otouto) (AKA @mokubot, channel: @otouto), a multipurpose Lua bot.\nGroup Butler wouldn't exist without it.\n\nThe owner of this bot is @baconn, do not pm him: use /groups command instead.\n\nBot version: `%s`\n*Some useful links:*
+This bot is based on [otouto](https://github.com/topkecleon/otouto) (AKA @mokubot, channel: @otouto), a multipurpose Lua bot.
+Group Butler wouldn't exist without it.
+
+The owner of this bot is @baconn, do not pm him: use /groups command instead.
+
+Bot version: `%s`
+*Some useful links:*
 ]]):format(config.human_readable_version)
 		api.sendMessage(msg.chat.id, text, true, keyboard)
 	end
@@ -56,7 +62,13 @@ function plugin.onCallbackQuery(msg, blocks)
 	if blocks[1] == 'about' then
 		local keyboard = do_keyboard_credits()
 		local text = i18n([[
-This bot is based on [otouto](https://github.com/topkecleon/otouto) (AKA @mokubot, channel: @otouto), a multipurpose Lua bot.\nGroup Butler wouldn't exist without it.\n\nThe owner of this bot is @baconn, do not pm him: use /groups command instead.\n\nBot version: `%s`\n*Some useful links:*
+This bot is based on [otouto](https://github.com/topkecleon/otouto) (AKA @mokubot, channel: @otouto), a multipurpose Lua bot.
+Group Butler wouldn't exist without it.
+
+The owner of this bot is @baconn, do not pm him: use /groups command instead.
+
+Bot version: `%s`
+*Some useful links:*
 ]]):format(config.human_readable_version)
 		api.editMessageText(msg.chat.id, msg.message_id, text, true, keyboard)
 	end

--- a/lua/plugins/private_settings.lua
+++ b/lua/plugins/private_settings.lua
@@ -10,9 +10,9 @@ local function get_button_description(key)
 	if key == 'rules_on_join' then
 		return i18n("When you join a group moderated by this bot, you will receive the group rules in private")
 	elseif key == 'reports' then
-		return i18n(
-			'If enabled, you will receive all the messages reported with the @admin command in the groups you are moderating'
-			)
+		return i18n([[
+			If enabled, you will receive all of the messages reported with the @admin command in the groups you are moderating
+			]])
 	else
 		return i18n("Description not available")
 	end

--- a/lua/plugins/report.lua
+++ b/lua/plugins/report.lua
@@ -19,9 +19,10 @@ local function report(msg, description)
 		'• <b>Message reported by</b>: %s (<code>%d</code>)'):format(u.getname_final(msg.from), msg.from.id)
 	local chat_link = db:hget('chat:'..msg.chat.id..':links', 'link')
 	if msg.reply.forward_from or msg.reply.forward_from_chat or msg.reply.sticker then
-		text = text..i18n(
-			'\n• <b>Reported message sent by</b>: %s (<code>%d</code>)'
-			):format(u.getname_final(msg.reply.from), msg.reply.from.id)
+		text = text..i18n([[
+
+• <b>Reported message sent by</b>: %s (<code>%d</code>)
+		]]):format(u.getname_final(msg.reply.from), msg.reply.from.id)
 	end
 	if chat_link then
 		text = text..i18n('\n• <b>Group</b>: <a href="%s">%s</a>'):format(chat_link, msg.chat.title:escape_html())
@@ -29,9 +30,9 @@ local function report(msg, description)
 		text = text..i18n('\n• <b>Group</b>: %s'):format(msg.chat.title:escape_html())
 	end
 	if msg.chat.username then
-		text = text..i18n(
-			'\n• <a href="%s">Go to the message</a>'
-			):format('telegram.me/'..msg.chat.username..'/'..msg.message_id)
+		text = text..i18n([[
+
+• <a href="%s">Go to the message</a>]]):format('telegram.me/'..msg.chat.username..'/'..msg.message_id)
 	end
 	if description then
 		text = text..i18n('\n• <b>Description</b>: <i>%s</i>'):format(description:escape_html())
@@ -95,9 +96,8 @@ function plugin.onTextMessage(msg, blocks)
 				local hash = 'chat:'..msg.chat.id..':report'
 				db:hset(hash, 'times_allowed', times_allowed)
 				db:hset(hash, 'duration', (duration * 60))
-				text = i18n(
-					'*New parameters saved*.\nUsers will be able to use @admin %d times/%d minutes'
-					):format(times_allowed, duration)
+				text = i18n([[*New parameters saved*.
+Users will be able to use @admin %d times/%d minutes]]):format(times_allowed, duration)
 			end
 			api.sendReply(msg, text, true)
 		else

--- a/lua/plugins/rules.lua
+++ b/lua/plugins/rules.lua
@@ -61,12 +61,12 @@ function plugin.onTextMessage(msg, blocks)
 		local rules = blocks[2]
 		--ignore if not input text
 		if not rules then
-			api.sendReply(msg, i18n("Please write something next `/setrules`"), true) return
+			api.sendReply(msg, i18n("Please write something after `/setrules`"), true) return
 		end
 		--check if a mod want to clean the rules
 		if rules == '-' then
 			db:hdel(hash, 'rules')
-			api.sendReply(msg, i18n("Rules has been deleted."))
+			api.sendReply(msg, i18n("Rules have been deleted."))
 			return
 		end
 

--- a/lua/plugins/service.lua
+++ b/lua/plugins/service.lua
@@ -38,11 +38,13 @@ function plugin.onTextMessage(msg, blocks)
 		-- send manuals
 		local text
 		if blocks[1] == 'new_chat_member:bot' then
-			text = i18n("Hello everyone!\n"
-				.. "My name is %s, and I'm a bot made to help administrators in their hard work.\n")
+			text = i18n([[Hello everyone!
+"My name is %s, and I'm a bot made to help administrators in their hard work.
+				]])
 				:format(bot.first_name:escape())
 		else
-			text = i18n("Yay! This group has been upgraded. You are great! Now I can work properly :)\n")
+			text = i18n([[Yay! This group has been upgraded. You are great! Now I can work properly :)
+			]])
 		end
 		--[[if not u.is_admin(msg.chat.id, bot.id) then
 			if u.is_owner(msg.chat.id, msg.from.id) then

--- a/lua/plugins/users.lua
+++ b/lua/plugins/users.lua
@@ -155,7 +155,7 @@ function plugin.onTextMessage(msg, blocks)
 		if not msg.reply
 			and (not blocks[2] or (not blocks[2]:match('@[%w_]+$') and not blocks[2]:match('%d+$')
 			and not msg.mention_id)) then
-			api.sendReply(msg, i18n("Reply to an user or mention them by username or numerical ID"))
+			api.sendReply(msg, i18n("Reply to a user or mention them by username or numerical ID"))
 			return
 		end
 
@@ -181,7 +181,9 @@ If you're using it by username and want to teach me who the user is, forward me 
 		local hash = 'cache:chat:'..msg.chat.id..':admins'
 		local seconds = db:ttl(hash)
 		local cached_admins = db:scard(hash)
-		local text = i18n("📌 Status: `CACHED`\n⌛ ️Remaining: `%s`\n👥 Admins cached: `%d`")
+		local text = i18n([[📌 Status: `CACHED`
+⌛ ️Remaining: `%s`
+👥 Admins cached: `%d`]])
 			:format(get_time_remaining(tonumber(seconds)), cached_admins)
 		local keyboard = do_keyboard_cache(msg.chat.id)
 		api.sendMessage(msg.chat.id, text, true, keyboard)
@@ -236,7 +238,9 @@ function plugin.onCallbackQuery(msg, blocks)
 			u.cache_adminlist(msg.target_id)
 			local cached_admins = db:smembers('cache:chat:'..msg.target_id..':admins')
 			local time = get_time_remaining(config.bot_settings.cache_time.adminlist)
-			local text = i18n("📌 Status: `CACHED`\n⌛ ️Remaining: `%s`\n👥 Admins cached: `%d`")
+			local text = i18n([[📌 Status: `CACHED`
+⌛ ️Remaining: `%s`
+👥 Admins cached: `%d`]])
 				:format(time, #cached_admins)
 			api.answerCallbackQuery(msg.cb_id, i18n("✅ Updated. Next update in %s"):format(time))
 			api.editMessageText(msg.chat.id, msg.message_id, text, true, do_keyboard_cache(msg.target_id))

--- a/lua/plugins/warn.lua
+++ b/lua/plugins/warn.lua
@@ -76,9 +76,10 @@ function plugin.onTextMessage(msg, blocks)
 		local removed = forget_user_warns(msg.chat.id, msg.reply.from.id)
 		local admin = u.getname_final(msg.from)
 		local user = u.getname_final(msg.reply.from)
-		local text = i18n(
-			'Done! %s has been forgiven.\n<b>Warns found</b>: <i>normal warns %s, for media %s, spamwarns %s</i>'
-			):format(user, removed.normal or 0, removed.media or 0, removed.spam or 0)
+		local text = i18n([[
+			Done! %s has been forgiven.
+			<b>Warnings found</b>: <i>normal warnings %s, media warnings %s, spam warnings %s</i>
+			]]):format(user, removed.normal or 0, removed.media or 0, removed.spam or 0)
 		api.sendReply(msg, text, 'html')
 		u.logEvent('nowarn', msg, {admin = admin, user = user, user_id = msg.reply.from.id, rem = removed})
 	end
@@ -112,8 +113,8 @@ function plugin.onTextMessage(msg, blocks)
 			--if kick/ban fails, send the motivation
 			if not res then
 				if not motivation then
-					motivation = i18n("I can't kick this user.\n"
-						.. "Probably I'm not an Admin, or the user is an Admin iself")
+					motivation = i18n([[I can't kick this user.
+Either I am not an admin, or the user is!]])
 				end
 				if num > nmax then db:hset(hash, msg.reply.from.id, nmax) end --avoid to have a number of warnings bigger than the max
 				text = motivation

--- a/lua/plugins/welcome.lua
+++ b/lua/plugins/welcome.lua
@@ -58,7 +58,7 @@ local function apply_default_permissions(chat_id, users)
 			local chat_member = api.getChatMember(chat_id, users[i].id)
 			for j=1, #permissions do
 				if chat_member.result[permissions[j]] == false then
-					-- the user has already been restricted: just force-restrict this permission 
+					-- the user has already been restricted: just force-restrict this permission
 					def_permissions[permissions[j]] = false
 				elseif not def_permissions[permissions[j]] then
 					-- no default value set for this permission, use the default in config.lua


### PR DESCRIPTION
For example, this:
![Before image](https://a.doko.moe/hzhcqy.png)
Becomes this:
![After image](https://a.doko.moe/tsjtci.png)

And this:
![Default](https://a.doko.moe/sadxro.png)
Becomes this:
![Default woo](https://a.doko.moe/mkpnir.png)