### PR TITLE
Use lua 5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yangm97/lua:5.2-alpine
+FROM yangm97/lua:5.1-alpine
 
 WORKDIR /srv/app
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Requirements:
 - Optional: GitLab repository for CI/CD
 
 ### Running (dev mode)
-Run `docker-compose up`. Docker will pull and build the required images, so the first time you run this command should take a little while. After that, the bot should be up and running. 
+Run `docker-compose up`. Docker will pull and build the required images, so the first time you run this command should take a little while. After that, the bot should be up and running.
 
 Code is mounted on the bot container, so you can make changes and restart the bot as you normally would. There’s no need to use `docker-compose up --build` or `docker-compose build` unless you changed something on `Dockerfile`.
 
-Redis default port is mounted to host, just in case you want to debug something using tools available at the host. 
+Redis default port is mounted to host, just in case you want to debug something using tools available at the host.
 
 **The redis container is set to not persist data while in dev mode**.
 
@@ -67,7 +67,7 @@ Files named `docker-compose.*.yml` are gitignored, just in case you feel the nee
 The bot also supports reading Docker Secrets (may work with other vaults too). Check `lua/config.lua` to see which variables can be read from secrets.
 
 #### Compose Example
-You would need to write another override file (i.e. `docker-compose.deploy.yml`) matching your needs (change restart policy to always, either add groupbutler to an external network or create a redis service with persistency, etc.). 
+You would need to write another override file (i.e. `docker-compose.deploy.yml`) matching your needs (change restart policy to always, either add groupbutler to an external network or create a redis service with persistency, etc.).
 
 You could deploy Group Butler by running something like this:
 
@@ -90,8 +90,8 @@ Assuming you have deployed redis into `staging` (`docker stack deploy …` or `d
 List of required packages:
 - `libreadline-dev`
 - `redis-server`
-- `lua5.2`
-- `liblua5.2dev`
+- `lua5.1`
+- `liblua5.1dev`
 - `libssl-dev`
 - `git`
 - `make`
@@ -119,7 +119,7 @@ or
 
 $ sudo apt-get update
 $ sudo apt-get upgrade
-$ sudo apt-get install libreadline-dev libssl-dev lua5.2 liblua5.2-dev git make unzip redis-server curl libcurl4-gnutls-dev
+$ sudo apt-get install libreadline-dev libssl-dev lua5.1 liblua5.1-dev git make unzip redis-server curl libcurl4-gnutls-dev
 
 # We are going now to install LuaRocks and the required Lua modules
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,3 @@ services:
       - TG_WEBHOOK_CERT
       - TG_WEBHOOK_MAX_CON
     image: ${IMAGE:-groupbutler}:${TAG:-latest}
-    # tty: true # needed when using lua 5.1

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Lua Version
-LUA=5.2
+LUA=5.1
 
 # Dependencies and libraries
 NATIVE="luarocks lua$LUA liblua$LUA-dev git make unzip redis-server curl libcurl4-gnutls-dev"

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -67,7 +67,7 @@ local function on_msg_receive(msg, callback) -- The fn run whenever a message is
 	if msg.chat.type ~= 'group' then --do not process messages from normal groups
 		if msg.date < os.time(os.date("!*t")) - 7 then print('Old update skipped') return end -- Do not process old messages.
 		-- os.time(os.date("!*t")) is used so that the timestamp is returned from UTC, not the current timezone.
-		-- the ! indicates UTC - https://www.lua.org/manual/5.2/manual.html#pdf-os.date
+		-- the ! indicates UTC - https://www.lua.org/manual/5.1/manual.html#pdf-os.date
 		if not msg.text then msg.text = msg.caption or '' end
 
 		locale.language = db:get('lang:'..msg.chat.id) or config.lang --group language


### PR DESCRIPTION
Closes #298 and #301 

Docker support was added using lua 5.2 because of a bug which required tty for lua 5.1 inside docker. Openresty (used by the soon™ to be merged webhooks mode PR) uses luajit, which supports lua 5.1. 

In order to prevent future issues by diverging versions (although #298 is caused by a bug in lua-cjson indeed), I propose to use lua 5.1 in polling mode.